### PR TITLE
Add: support cold reboot tests by pdu

### DIFF
--- a/checkbox-provider-ce-oem/bin/cold_reboot_by_pdu.sh
+++ b/checkbox-provider-ce-oem/bin/cold_reboot_by_pdu.sh
@@ -70,6 +70,10 @@ main() {
 
     if [ "$pdu_type" == "apc" ]; then
         cold_reboot_apc
+    else
+        echo -e "Error: Network PDU type is not supported!\n"
+        help_function
+        exit 1
     fi
 }
 
@@ -91,8 +95,8 @@ while getopts "t:p:d:" opt; do
     esac
 done
 
-if  [[ "$pdu_type" != "apc" ]]; then
-    echo -e "Error: Network PDU type is not supported!\n"
+if  [ -z "$pdu_type" ]; then
+    echo -e "Error: Network PDU variable is needed!\n"
     help_function
     exit 1
 fi

--- a/checkbox-provider-ce-oem/bin/cold_reboot_by_pdu.sh
+++ b/checkbox-provider-ce-oem/bin/cold_reboot_by_pdu.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+ip=""
+outlet_port=""
+pdu_type=""
+reboot_duration=""
+
+cold_reboot_apc() {
+    echo "Turn off the power of DUT by APC network PDU.."
+    echo "System should be back after around $reboot_duration seconds.."
+    echo ""
+
+    # change the duration of power reboot
+    oid="1.3.6.1.4.1.318.1.1.4.5.2.1.5.$outlet_port"
+    i=0
+    result="fail"
+    while [ $i -le 3 ]
+    do
+        echo "## change the duration of power reboot"
+        snmpset -v1 -c private "$ip" "$oid" integer "$reboot_duration" > /dev/null
+        ret="$?"
+        if [ "$ret" == 0 ]; then
+            echo "changed the duration successfully!"
+            result="pass"
+            break
+        fi
+        sleep 1
+        i=$((i + 1))
+    done
+    if [ $result == "fail" ]; then
+        echo "## failed to change the duration of power reboot"  >&2
+        exit 1
+    fi
+
+    # power cycle a outlet with delay
+    echo ""
+    oid="1.3.6.1.4.1.318.1.1.4.4.2.1.3.$outlet_port"
+    i=0
+    result="fail"
+    while [ $i -le 3 ]
+    do
+        echo "## trigger a cold reboot by network PDU.."
+        # 1: power on, 2: power off, 3: power cycle
+        snmpset -v1 -c private "$ip" "$oid" integer 3 > /dev/null
+        ret="$?"
+        if [ "$ret" == 0 ]; then
+            echo "trigger a cold reboot successfully!"
+            result="pass"
+            break
+        fi
+        sleep 1
+        i=$((i + 1))
+    done
+    if [ $result == "fail" ]; then
+        echo "## failed to trigger a cold reboot" >&2
+        exit 1
+    fi
+}
+
+
+main() {
+    ip=$(echo $pdu_var | awk -F ':' '{print $1}')
+    outlet_port=$(echo $pdu_var | awk -F ':' '{print $2}')
+
+    if [[ -z "$ip" || -z "$outlet_port" ]]; then
+        echo -e "Error: PDU variable format is unexpected!\n"
+        help_function
+        exit 1
+    fi
+
+    if [ "$pdu_type" == "apc" ]; then
+        cold_reboot_apc
+    fi
+}
+
+help_function() {
+    echo "This script is uses for trigger a cold reboot test by network PDU"
+    echo
+    echo "Usage: cold_reboot_by_pdu.sh -t type -p pud-ip:outlet-port"
+    echo -e "\t-t    Network PDU type. [apc]"
+    echo -e "\t-p    Network PDU IP and outlet port. e.g. 10.120.33.44:2"
+    echo -e "\t-d    Reboot delay duration. Default delay is 60 (seconds)"
+}
+
+while getopts "t:p:d:" opt; do
+    case "$opt" in
+        t) pdu_type="$OPTARG" ;;
+        p) pdu_var="$OPTARG" ;;
+        d) reboot_duration="$OPTARG" ;;
+        ?) help_function ;;
+    esac
+done
+
+if  [[ "$pdu_type" != "apc" ]]; then
+    echo -e "Error: Network PDU type is not supported!\n"
+    help_function
+    exit 1
+fi
+
+if [ -z "$pdu_var" ]; then
+    echo -e "Error: PDU variable is needed!\n"
+    help_function
+    exit 1
+fi
+
+if [ -z "$reboot_duration" ]; then
+    echo -e "Applied 60s to the Reboot delay duration!\n"
+    reboot_duration=60
+fi
+
+main

--- a/checkbox-provider-ce-oem/bin/cold_reboot_by_pdu.sh
+++ b/checkbox-provider-ce-oem/bin/cold_reboot_by_pdu.sh
@@ -59,8 +59,8 @@ cold_reboot_apc() {
 
 
 main() {
-    ip=$(echo $pdu_var | awk -F ':' '{print $1}')
-    outlet_port=$(echo $pdu_var | awk -F ':' '{print $2}')
+    ip=$(echo "$pdu_var" | awk -F ':' '{print $1}')
+    outlet_port=$(echo "$pdu_var" | awk -F ':' '{print $2}')
 
     if [[ -z "$ip" || -z "$outlet_port" ]]; then
         echo -e "Error: PDU variable format is unexpected!\n"

--- a/checkbox-provider-ce-oem/bin/reboot_check_test.sh
+++ b/checkbox-provider-ce-oem/bin/reboot_check_test.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+device_check="true"
+service_check="true"
+
+service_check() {
+    echo -e "\n## Check system service.."
+    COUNT=$(systemctl --system --no-ask-password --no-pager --no-legend list-units --state=failed | wc -l)
+    printf "Found %s failed units\n" "$COUNT"
+    if [ "$COUNT" != 0 ]; then
+        printf "\nFailed units:\n"
+        systemctl --system --no-ask-password --no-pager list-units --state=failed
+        service_check="false"
+    fi
+}
+
+dump() {
+    echo "## Dump the devices.."
+    mkdir -p "$output_dir"
+    lspci -i "$SNAP"/usr/share/misc/pci.ids > "$output_dir"/lspci_log
+    iw dev | grep "Interface\|addr\|ssid" > "$output_dir"/wifi_conn
+    checkbox-support-lsusb -f "$CHECKBOX_RUNTIME"/var/lib/usbutils/usb.ids -s | sort > "$output_dir"/lsusb_log
+    echo "dump devices complete"
+}
+
+compare() {
+    echo -e "\n## Compare the devices.."
+    if ! diff -u "$compare_dir"/lspci_log "$output_dir"/lspci_log; then
+        echo "lspci mismatch during cycle"
+        device_check="false"
+    fi
+    if ! diff -u "$compare_dir"/wifi_conn "$output_dir"/wifi_conn; then
+        echo "wifi mismatch during cycle"
+        device_check="false"
+    fi
+    if ! diff -u "$compare_dir"/lsusb_log "$output_dir"/lsusb_log; then
+        echo "lsusb mismatch during cycle"
+        device_check="false"
+    fi
+
+    [[ "$device_check" == "true" ]] && echo "Device match during reboot cycle"
+}
+
+main() {
+    if  [[ -n "$output_dir" ]]; then
+        dump
+    fi
+
+    if [[ -n "$compare_dir" ]]; then
+        if  [[ -z "$output_dir" ]]; then
+            echo -e "Error: Please provide output directory!\n"
+            help_function
+            exit 1
+        fi
+        compare
+    fi
+
+    if [[ -n "$service_opt" ]]; then
+        service_check
+    fi
+
+    if [[ -n "$service_opt" && "$service_check" == "false" ]] || \
+       [[ -n "$compare_dir" && "$device_check" == "false" ]]; then
+        exit 1
+    fi
+}
+
+
+help_function() {
+    echo "This script is uses for collect device and compare the difference of device during every reboot iteration"
+    echo
+    echo "Usage: cold_reboot_by_pdu.sh -t type -p pud-ip:outlet-port"
+    echo -e "\t-d    Output directory."
+    echo -e "\t-c    The target directory for comparing device"
+    echo -e "\t-s    Do service check"
+}
+
+service_opt=""
+output_dir=""
+compare_dir=""
+while getopts "d:c:s" opt; do
+    case "$opt" in
+        d) output_dir="$OPTARG" ;;
+        c) compare_dir="$OPTARG" ;;
+        s) service_opt="True" ;;
+        ?) help_function ;;
+    esac
+done
+
+main

--- a/checkbox-provider-ce-oem/bin/reboot_check_test.sh
+++ b/checkbox-provider-ce-oem/bin/reboot_check_test.sh
@@ -15,12 +15,13 @@ service_check() {
 }
 
 dump() {
-    echo "## Dump the devices.."
+    echo "## Dump the devices information to $output_dir.."
     mkdir -p "$output_dir"
     lspci -i "$SNAP"/usr/share/misc/pci.ids > "$output_dir"/lspci_log
     iw dev | grep "Interface\|addr\|ssid" > "$output_dir"/wifi_conn
     checkbox-support-lsusb -f "$CHECKBOX_RUNTIME"/var/lib/usbutils/usb.ids -s | sort > "$output_dir"/lsusb_log
     echo "dump devices complete"
+    sync
 }
 
 compare() {

--- a/checkbox-provider-ce-oem/units/power-management/jobs.pxu
+++ b/checkbox-provider-ce-oem/units/power-management/jobs.pxu
@@ -1,0 +1,36 @@
+id: power-management/cold-reboot-by-pdu
+category_id: com.canonical.plainbox::power-management
+_summary: Cold reboot
+_description:
+    This tests powers off the system and then powers it on using Network PDU
+    The 'NETWORK_PDU_CONF,NETWORK_PDU_TYPE,STRESS_BOOT_WAIT_DELAY,STRESS_BOOT_WAKEUP_DELAY' need to be provided as following format
+    format:
+        NETWORK_PDU_CONF=$ip:$outlet_port
+        NETWORK_PDU_TYPE=$vendor
+        STRESS_BOOT_WAKEUP_DELAY=$seconds
+        STRESS_BOOT_WAIT_DELAY=$seconds
+    e.g.
+        NETWORK_PDU_CONF=10.102.30.40:2
+        NETWORK_PDU_TYPE=apc
+        STRESS_BOOT_WAKEUP_DELAY=100
+        STRESS_BOOT_WAIT_DELAY=60
+unit: job
+plugin: shell
+command:
+    sleep 5
+    [[ -z "$STRESS_BOOT_WAKEUP_DELAY" ]] && STRESS_BOOT_WAKEUP_DELAY=60
+    cold_reboot_by_pdu.sh -t $NETWORK_PDU_TYPE -p $NETWORK_PDU_CONF -d "$STRESS_BOOT_WAKEUP_DELAY"
+user: root
+flags: preserve-locale noreturn autorestart
+estimated_duration: 300
+
+
+id: power-management/post-cold-reboot-by-pdu
+after: power-management/cold-reboot-by-pdu
+category_id: com.canonical.plainbox::power-management
+_summary: Post cold reboot service check
+_description: Check there are no failed services after the cold reboot
+unit: job
+plugin: shell
+command: reboot_check_test.sh -s
+estimated_duration: 1.0

--- a/checkbox-provider-ce-oem/units/power-management/test-plan.pxu
+++ b/checkbox-provider-ce-oem/units/power-management/test-plan.pxu
@@ -1,0 +1,7 @@
+id: power-automated-by-pdu
+unit: test plan
+_name: Automated power tests
+_description: Automated power tests for Snappy Ubuntu Core devices
+include:
+    power-management/cold-reboot-by-pdu
+    power-management/post-cold-reboot-by-pdu

--- a/checkbox-provider-ce-oem/units/stress/boot.pxu
+++ b/checkbox-provider-ce-oem/units/stress/boot.pxu
@@ -1,0 +1,106 @@
+
+id: init-boot-loop-data
+category_id: com.canonical.certification::stress-tests
+_summary: Generate the baseline data set to test against
+_description: This creates baseline data sets which be considered the master
+ copies and all further tests will be compared against these.
+unit: job
+plugin: shell
+command:
+    reboot_check_test.sh -o "$PLAINBOX_SESSION_SHARE/before_reboot"
+environ: LD_LIBRARY_PATH
+user: root
+estimated_duration: 1s
+flags: preserve-locale
+
+
+id: cold-boot-loop-by-pdu-reboot1
+category_id: com.canonical.certification::stress-tests/cold-boot
+_summary: Cold reboot with PDU - loop 1
+_description:
+    This tests powers off the system and then powers it on using Network PDU
+    The 'NETWORK_PDU_CONF,NETWORK_PDU_TYPE,STRESS_BOOT_WAIT_DELAY,STRESS_BOOT_WAKEUP_DELAY' need to be provided as following format
+    format:
+        NETWORK_PDU_CONF=$ip:$outlet_port
+        NETWORK_PDU_TYPE=$vendor
+        STRESS_BOOT_WAKEUP_DELAY=$seconds
+        STRESS_BOOT_WAIT_DELAY=$seconds
+    e.g.
+        NETWORK_PDU_CONF=10.102.30.40:2
+        NETWORK_PDU_TYPE=apc
+        STRESS_BOOT_WAKEUP_DELAY=100
+        STRESS_BOOT_WAIT_DELAY=60
+unit: job
+plugin: shell
+environ: STRESS_BOOT_WAKEUP_DELAY
+command:
+    cold_reboot_by_pdu.sh -t $NETWORK_PDU_TYPE -p $NETWORK_PDU_CONF -d "$STRESS_BOOT_WAKEUP_DELAY"
+user: root
+flags: preserve-locale noreturn autorestart
+estimated_duration: 300
+depends: init-boot-loop-data
+
+
+id: post-cold-boot-loop-by-pdu-reboot1
+after: cold-boot-loop-by-pdu-reboot1
+category_id: com.canonical.certification::stress-tests/cold-boot
+_summary: Post cold reboot service check - loop 1
+_description: Check there are no failed services after the cold reboot
+unit: job
+plugin: shell
+environ: LD_LIBRARY_PATH
+command:
+    reboot_check_test.sh -c "$PLAINBOX_SESSION_SHARE/before_reboot" -d "$PLAINBOX_SESSION_SHARE/reboot_cycle1" -s
+user: root
+flags: preserve-locale
+estimated_duration: 1.0
+depends: cold-boot-loop-by-pdu-reboot1
+
+
+id: cold-boot-loop-by-pdu-reboot{reboot_id}
+category_id: com.canonical.certification::stress-tests/cold-boot
+_summary: Cold reboot with PDU - loop {reboot_id}
+_description:
+    This tests powers off the system and then powers it on using Network PDU
+    The 'NETWORK_PDU_CONF,NETWORK_PDU_TYPE,STRESS_BOOT_WAIT_DELAY,STRESS_BOOT_WAKEUP_DELAY' need to be provided as following format
+    format:
+        NETWORK_PDU_CONF=$ip:$outlet_port
+        NETWORK_PDU_TYPE=$vendor
+        STRESS_BOOT_WAKEUP_DELAY=$seconds
+        STRESS_BOOT_WAIT_DELAY=$seconds
+    e.g.
+        NETWORK_PDU_CONF=10.102.30.40:2
+        NETWORK_PDU_TYPE=apc
+        STRESS_BOOT_WAKEUP_DELAY=100
+        STRESS_BOOT_WAIT_DELAY=60
+unit: template
+template-resource: com.canonical.certification::reboot-run-generator
+template-unit: job
+plugin: shell
+environ: STRESS_BOOT_WAKEUP_DELAY STRESS_BOOT_WAIT_DELAY NETWORK_PDU_TYPE NETWORK_PDU_CONF
+command:
+    sleep "${{STRESS_BOOT_WAIT_DELAY:-120}}"
+    cold_reboot_by_pdu.sh -t "${{NETWORK_PDU_TYPE}}" -p "${{NETWORK_PDU_CONF}}" -d "${{STRESS_BOOT_WAKEUP_DELAY:-120}}"
+user: root
+flags: preserve-locale noreturn autorestart
+estimated_duration: 300
+after: post-cold-boot-loop-by-pdu-reboot{reboot_id_previous}
+depends: init-boot-loop-data
+
+
+id: post-cold-boot-loop-by-pdu-reboot{reboot_id}
+after: cold-boot-loop-by-pdu-reboot{reboot_id}
+category_id: com.canonical.certification::stress-tests/cold-boot
+_summary: Post cold reboot service check - loop {reboot_id}
+_description: Check there are no failed services after the cold reboot
+unit: template
+template-resource: com.canonical.certification::reboot-run-generator
+template-unit: job
+plugin: shell
+environ: LD_LIBRARY_PATH
+command:
+    reboot_check_test.sh -c "$PLAINBOX_SESSION_SHARE/before_reboot" -d "$PLAINBOX_SESSION_SHARE/reboot_cycle{reboot_id}" -s
+user: root
+flags: preserve-locale
+estimated_duration: 1.0
+depends: cold-boot-loop-by-pdu-reboot{reboot_id}

--- a/checkbox-provider-ce-oem/units/stress/boot.pxu
+++ b/checkbox-provider-ce-oem/units/stress/boot.pxu
@@ -7,7 +7,7 @@ _description: This creates baseline data sets which be considered the master
 unit: job
 plugin: shell
 command:
-    reboot_check_test.sh -o "$PLAINBOX_SESSION_SHARE/before_reboot"
+    reboot_check_test.sh -d "$PLAINBOX_SESSION_SHARE/before_reboot"
 environ: LD_LIBRARY_PATH
 user: root
 estimated_duration: 1s

--- a/checkbox-provider-ce-oem/units/stress/test-plan.pxu
+++ b/checkbox-provider-ce-oem/units/stress/test-plan.pxu
@@ -1,0 +1,30 @@
+unit: test plan
+id: cold-boot-stress-test-by-pdu
+_name: Cold boot stress test with Network PDU
+_description:
+    Reboots the machine a pre-defined number of times and on
+    resumption of OS performs a hardware check to ensure all
+    items are still present. The reboot is delayed by few minutes
+    by the network PDU to allow hardware to cool.
+estimated_duration: 42h
+bootstrap_include:
+    com.canonical.certification::reboot-run-generator
+include:
+    cold-boot-loop-by-pdu-reboot.*
+    post-cold-boot-loop-by-pdu-reboot.*
+mandatory_include:
+    com.canonical.plainbox::manifest
+    com.canonical.certification::package
+    com.canonical.certification::snap
+    com.canonical.certification::uname
+    com.canonical.certification::lsb
+    com.canonical.certification::cpuinfo
+    com.canonical.certification::dpkg
+    com.canonical.certification::dmi_attachment
+    com.canonical.certification::sysfs_attachment
+    com.canonical.certification::udev_attachment
+    com.canonical.certification::lspci_attachment
+    com.canonical.certification::lsusb_attachment
+    com.canonical.certification::dmi
+    com.canonical.certification::meminfo
+    com.canonical.certification::interface


### PR DESCRIPTION
add cold reboot tests by network PDU for those system which not able to wakeup by rtc

# For power-automated-by-pdu
ceqa@ceqa:~$ checkbox.checkbox-cli list-bootstrapped com.canonical.qa.ceoem::power-automated-by-pdu
$PROVIDERPATH is defined, so following provider sources are ignored ['/home/ceqa/.local/share/plainbox-providers-1', '/var/tmp/checkbox-providers-develop'] 
Using sideloaded provider: checkbox-provider-ce-oem, version 0.1 from /var/tmp/checkbox-providers/checkbox-provider-ce-oem/checkbox-provider-ce-oem
com.canonical.qa.ceoem::power-management/cold-reboot-by-pdu
com.canonical.qa.ceoem::power-management/post-cold-reboot-by-pdu

# For cold-boot-stress-test-by-pdu
https://pastebin.canonical.com/p/YRgwFNzVvt/