### PR TITLE
Fix: rtc wakealarm checking to right attribute

### DIFF
--- a/checkbox-provider-ce-oem/units/rtc/jobs.pxu
+++ b/checkbox-provider-ce-oem/units/rtc/jobs.pxu
@@ -50,10 +50,10 @@ user: root
 category_id: com.canonical.certification::rtc_category
 estimated_duration: 5
 command: 
-    if [ -f "/sys/class/rtc/{rtc}/device/power/wakeup" ]; then 
+    if [ -f "/sys/class/rtc/{rtc}/wakealarm" ]; then 
         rtcwake -d {rtc} -v -m on -s 30
     else 
-        echo "{rtc} not support wakeup"
+        echo "{rtc} not support wakealarm"
         exit 1 
     fi
 flags: also-after-suspend


### PR DESCRIPTION
rtc alarm should be written into /sys/class/rtc/rtcX/wakealarm instead of /sys/class/rtc/rtcX/device/power/wakeup.