### PR TITLE
230426 add generic full plan

### DIFF
--- a/checkbox-provider-ce-oem/units/test-plan-ce-oem-full-classic.pxu
+++ b/checkbox-provider-ce-oem/units/test-plan-ce-oem-full-classic.pxu
@@ -1,0 +1,112 @@
+# Copyright 2023 Canonical Ltd.
+# All rights reserved.
+#
+# Test plans and (optionally) jobs unique to the IoT devices running Ubuntu Server.
+#
+
+id: ce-oem-iot-server-22-04
+unit: test plan
+_name: CE-OEM-IOT - Full manual + automated tests for Ubuntu Server 22.04
+_description:
+    Combined manual and automated test plans for the IoT devices running Ubuntu Server.
+include:
+nested_part:
+    ce-oem-iot-server-22-04-manual
+    ce-oem-iot-server-22-04-automated
+
+id: ce-oem-iot-server-20-04
+unit: test plan
+_name: CE-OEM-IOT - Full manual + automated tests for Ubuntu Server 20.04
+_description:
+    Combined manual and automated test plans for Ubuntu Server IoT devices.
+include:
+nested_part:
+    ce-oem-iot-server-20-04-manual
+    ce-oem-iot-server-20-04-automated
+
+
+id: ce-oem-iot-server-22-04-manual
+unit: test plan
+_name: CE-OEM-IOT - Manual only QA tests for Ubuntu Server 22.04
+_description:
+    Ubuntu Server QA test plan for the ce-oem-iot hardware. This test plan contains
+    all of the tests that require manual control of device hardware
+    or some other user input to complete.
+estimated_duration: 3600
+include:
+nested_part:
+    ce-oem-manual
+    com.canonical.certification::client-cert-iot-server-22-04-manual
+    after-suspend-ce-oem-automated
+exclude:
+    com.canonical.certification::ethernet/wol_S4_.*
+
+id: ce-oem-iot-server-20-04-manual
+unit: test plan
+_name: CE-OEM-IOT - Manual only QA tests for Ubuntu Server 20.04
+_description:
+    Ubuntu Server QA test plan for the ce-oem-iot hardware. This test plan contains
+    all of the tests that require manual control of device hardware
+    or some other user input to complete.
+estimated_duration: 3600
+include:
+nested_part:
+    ce-oem-automated
+    com.canonical.certification::client-cert-iot-server-20-04-manual
+    after-suspend-ce-oem-automated
+exclude:
+    com.canonical.certification::ethernet/wol_S4_.*
+
+
+id: ce-oem-iot-server-22-04-automated
+unit: test plan
+_name: CE-OEM-IOT - Automated only QA tests for Ubuntu Server 22.04
+_description:
+    Ubuntu Server QA test plan for the IoT hardware. This test plan contains
+    all of the automated tests used to validate the IoT device.
+include:
+nested_part:
+    ce-oem-automated
+    com.canonical.certification::client-cert-iot-server-22-04-automated
+    after-suspend-ce-oem-automated
+exclude:
+
+id: ce-oem-iot-server-20-04-automated
+unit: test plan
+_name: CE-OEM-IOT - Automated only QA tests for Ubuntu Server 20.04
+_description:
+ Ubuntu Server QA test plan for the ce-oem-iot hardware. This test plan contains
+ all of the automated tests used to validate the ce-oem-iot device.
+include:
+nested_part:
+    ce-oem-automated
+    com.canonical.certification::client-cert-iot-server-20-04-automated
+    after-suspend-ce-oem-automated
+exclude:
+
+id: ce-oem-iot-server-22-04-stress
+unit: test plan
+_name: CE-OEM-IOT - Stress tests for Ubuntu Server 22.04
+_description:
+ Ubuntu Server QA test plan that includes all stress tests required for IoT devices
+include:
+nested_part:
+    com.canonical.certification::stress-iperf3-automated                       # keep if ethernet is supported
+    com.canonical.certification::client-cert-iot-server-22-04-stress
+    ce-oem-stress
+exclude:
+    com.canonical.certification::stress-tests/hibernate.*
+
+
+id: ce-oem-iot-server-20-04-stress
+unit: test plan
+_name: CE-OEM-IOT - Stress tests for Ubuntu Server 20.04
+_description:
+ Ubuntu Server QA test plan that includes all stress tests required for IoT devices
+include:
+nested_part:
+    com.canonical.certification::stress-iperf3-automated                       # keep if ethernet is supported
+    com.canonical.certification::client-cert-iot-server-20-04-stress
+    ce-oem-stress
+exclude:
+    com.canonical.certification::stress-tests/hibernate.*

--- a/checkbox-provider-ce-oem/units/test-plan-ce-oem-full-core.pxu
+++ b/checkbox-provider-ce-oem/units/test-plan-ce-oem-full-core.pxu
@@ -1,0 +1,124 @@
+# Copyright 2023 Canonical Ltd.
+# All rights reserved.
+#
+# Test plans and (optionally) jobs unique to the IoT devices running Ubuntu Core.
+#
+
+id: ce-oem-iot-ubuntucore-22
+unit: test plan
+_name: CE-OEM-IOT - Full manual + automated tests for Ubuntu Core 22
+_description:
+ Combined manual and automated test plans for IoT device running Ubuntu Core.
+include:
+nested_part:
+    ce-oem-iot-ubuntucore-22-manual
+    ce-oem-iot-ubuntucore-22-automated
+
+id: ce-oem-iot-ubuntucore-20
+unit: test plan
+_name: CE-OEM-IOT - Full manual + automated tests for Ubuntu Core 20
+_description:
+ Combined manual and automated test plans for IoT device running Ubuntu Core.
+include:
+nested_part:
+    ce-oem-iot-ubuntucore-20-manual
+    ce-oem-iot-ubuntucore-20-automated
+
+id: ce-oem-iot-ubuntucore-22-manual
+unit: test plan
+_name: CE-OEM-IOT - Manual only QA tests for Ubuntu Core 22
+_description:
+ Ubuntu Core QA test plan for the IoT hardware. This test plan contains
+ all of the tests that require manual control of device hardware
+ or some other user input to complete.
+estimated_duration: 3600
+include:
+    com.canonical.certification::disk/encryption/check-fde-tpm                 # keep if FDE with TPM is enabled
+    com.canonical.certification::ubuntucore/kernel-failboot-.*                 # keep if kernel snap is not pc-kernel
+nested_part:
+    ce-oem-manual
+    com.canonical.certification::client-cert-iot-ubuntucore-22-manual
+    after-suspend-ce-oem-manual
+exclude:
+    com.canonical.certification::ethernet/wol_S4_.*
+
+
+id: ce-oem-ubuntucore-20-manual
+unit: test plan
+_name: CE-OEM-IOT - Manual only QA tests for Ubuntu Core 20
+_description:
+ Ubuntu Core QA test plan for the IoT hardware. This test plan contains
+ all of the tests that require manual control of device hardware
+ or some other user input to complete.
+estimated_duration: 3600
+include:
+    com.canonical.certification::disk/encryption/check-fde-tpm                 # keep if FDE with TPM is enabled
+    com.canonical.certification::ubuntucore/kernel-failboot-.*                 # keep if kernel snap is not pc-kernel
+nested_part:
+    ce-oem-manual
+    com.canonical.certification::client-cert-iot-ubuntucore-20-manual
+    after-suspend-ce-oem-manual
+exclude:
+    com.canonical.certification::ethernet/wol_S4_.*
+
+
+id: ce-oem-iot-ubuntucore-22-automated
+unit: test plan
+_name: CE-OEM-IOT - Automated only QA tests for Ubuntu Core 22
+_description:
+ Ubuntu Core QA test plan for the IoT hardware. This test plan contains
+ all of the automated tests used to validate the IoT device.
+include:
+    com.canonical.certification::image/model-grade
+    com.canonical.certification::miscellanea/secure_boot_mode_.*               # keep if secure boot is enabled
+    com.canonical.certification::disk/encryption/detect                        # keep if FDE is enabled
+nested_part:
+    ce-oem-automated
+    com.canonical.certification::client-cert-iot-ubuntucore-22-automated
+    after-suspend-ce-oem-automated
+exclude:
+
+
+id: ce-oem-iot-ubuntucore-20-automated
+unit: test plan
+_name: CE-OEM-IOT - Automated only QA tests for Ubuntu Core 20
+_description:
+ Ubuntu Core QA test plan for the IoT hardware. This test plan contains
+ all of the automated tests used to validate the IoT device.
+include:
+    com.canonical.certification::image/model-grade
+    com.canonical.certification::miscellanea/secure_boot_mode_.*               # keep if secure boot is enabled
+    com.canonical.certification::disk/encryption/detect                        # keep if FDE is enabled
+nested_part:
+    ce-oem-automated
+    com.canonical.certification::client-cert-iot-ubuntucore-20-automated
+    after-suspend-ce-oem-automated
+exclude:
+
+
+id: ce-oem-iot-ubuntucore-22-stress
+unit: test plan
+_name: CE-OEM-IOT - Stress tests for Ubuntu Core 22
+_description:
+ Ubuntu Core QA test plan that includes all stress tests required for IoT devices
+include:
+nested_part:
+    com.canonical.certification::stress-iperf3-automated                       # keep if ethernet is supported
+    com.canonical.certification::client-cert-iot-ubuntucore-22-stress
+    ce-oem-stress
+exclude:
+    com.canonical.certification::stress-tests/hibernate.*
+
+
+id: ce-oem-iot-ubuntucore-20-stress
+unit: test plan
+_name: CE-OEM-IOT - Stress tests for Ubuntu Core 20
+_description:
+ Ubuntu Core QA test plan that includes all stress tests required for IoT devices
+include:
+nested_part:
+    com.canonical.certification::stress-iperf3-automated                       # keep if ethernet is supported
+    com.canonical.certification::client-cert-iot-ubuntucore-20-stress
+    ce-oem-stress
+exclude:
+    com.canonical.certification::stress-tests/hibernate.*

--- a/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
+++ b/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
@@ -65,7 +65,6 @@ nested_part:
     ce-oem-rs485-automated
     ce-oem-eeprom-automated
     ce-oem-led-automated
-    ce-oem-power-automated-by-pdu
 
 id: after-suspend-ce-oem-manual
 unit: test plan


### PR DESCRIPTION
commit 904f8312d0d31cab1e0075c76c9cd9aef24b3819 (HEAD -> 230426_add-generic-full-plan, origin/230426_add-generic-full-plan)
Author: stanley31huang <stanley.huang@canonical.com>
Date:   Wed Apr 26 13:53:54 2023 +0800

    Add: add a generic iot test plans
    
    Adding a generic IoT test plans, it's a full testing set include tests
    in certification test plan and ce-oem-generic test plan

commit 0d285ca70a1ef47cf0db2922a674d71cd078295d
Author: stanley31huang <stanley.huang@canonical.com>
Date:   Wed Apr 26 13:48:34 2023 +0800

    Fix: remove ce-oem-power-automated-by-pdu
    
    Remove the ce-oem-power-automated-by-pdu from the ce-oem-automated
    The ce-oem-power-automated-by-pud will always be executed even the user
    not intend to reboot the DUT by PDU. And the checkbox session will stuck
    after send out a snmpset command.
    
    So remove this test first, and we need to integrate the cold boot
    related tests to PPC to support cold reboot test for those DUT which not
    able to wake up by rtc.