### PR TITLE
Improve the MTD script

### DIFF
--- a/checkbox-provider-ce-oem/bin/mtd.sh
+++ b/checkbox-provider-ce-oem/bin/mtd.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
-MTDS=$(ls /dev/mtd[0-9] | awk -F "/" '{print $3}')
+MTDS=$(find /dev -regex '.*mtd[0-9][0-9]?' | awk -F "/" '{print $3}')
+MTD_WRITEABLE_FLAG=0x400
 
 listAllMtd() {
     for c in ${MTDS}; do
@@ -10,7 +11,7 @@ listAllMtd() {
 }
 
 countMtd() {
-    count=$( listAllMtd | grep "MTD_NAME" | wc -l)
+    count=$( listAllMtd | grep -c "MTD_NAME")
     if [ "${1}" == "$count" ]; then
         echo "The number of MTD is correct!"
     else
@@ -19,41 +20,55 @@ countMtd() {
     fi
 }
 
-# This function will get the size of MTD.
+# This function will get the size of MTD. (Unit: byte)
 # size_hex is the MTD size convert to HEX, and it's for read and write the file to MTD.
-# size=$(awk '/mtd.size/ {print $3}' <<< "$info")
-# size_hex=$(printf '%x' "$size")
+# is_mtd_writable tells this MTD can be written or not (0 means read-only)
 infoMtd() {
     info=$(mtd_debug info /dev/"$1")
     echo "##### MTD info #####"
     echo "$info"
     size=$(awk '/mtd.size/ {print $3}' <<< "$info")
     size_hex=$(printf '%x' "$size")
+    mtd_flag=$(cat /sys/class/mtd/"$1"/flags)
+    is_mtd_writable=$((MTD_WRITEABLE_FLAG & mtd_flag))
 }
 
 createTestFile() {
+# $1 is the file path who will be used as random test file
+# $2 is size of random test file (Unit: byte)
     echo "##### Create test file #####"
-    dd if=/dev/urandom of="$writeFile" bs=1 count="$1"
+    dd if=/dev/urandom of="$1" bs=1 count="$2"
 }
 
 eraseMtd() {
+# $1 is the specific mtd. e.g. mtd1
+# $2 is size of random test file (Unit: byte)
     echo "##### Erase MTD #####"
     mtd_debug erase /dev/"$1" 0x0 0x"$2"
 }
 
 writeMtd() {
+# $1 is the specific mtd. e.g. mtd1
+# $2 is size of random test file. Should be the value of size_hex variable
+# $3 is the path of source file
     echo "##### Write MTD #####"
-    mtd_debug write /dev/"$1" 0x0 0x"$2" "$writeFile"
+    mtd_debug write /dev/"$1" 0x0 0x"$2" "$3"
 }
 
 readMtd() {
+# $1 is the specific mtd. e.g. mtd1
+# $2 is size of random test file. Should be the value of size_hex variable
+# $3 is the path of destination file
     echo "##### Read MTD #####"
-    mtd_debug read /dev/"$1" 0x0 0x"$2" "$readFile"
+    mtd_debug read /dev/"$1" 0x0 0x"$2" "$3"
 }
 
 compareFile() {
+# $1 is the path of compared file 1
+# $2 is the path of compared file 2
+# $3 is the specific mtd. e.g. mtd1
     echo "##### Compare File #####"
-    diff "$writeFile" "$readFile" && echo "$1 read and write file are consistency!" || (echo "$1 read and write file are inconsistency!!" ; exit 1)
+    diff "$1" "$2" && echo "$3 read and write file are consistency!" || (echo "$3 read and write file are inconsistency!!" ; exit 1)
 }
 
 main(){
@@ -61,15 +76,36 @@ main(){
 # $2 is MTD device name. e.g. mtd0, mtd1 ...etc
     case ${1} in
         list) listAllMtd ;;
-        compare) 
-            writeFile=$(mktemp)
-            readFile=$(mktemp)
+        compare)
             infoMtd "${2}"
-            createTestFile "$size"
-            eraseMtd "${2}" "$size_hex"
-            writeMtd "${2}" "$size_hex"
-            readMtd "${2}" "$size_hex"
-            compareFile "${2}" ;;
+            echo
+
+            # Read-only
+            if [[ $is_mtd_writable -eq "0" ]]; then
+                echo "${2} is read-olny"
+                readFile=$(mktemp)
+                echo "1. Read content to $readFile"
+                readMtd "${2}" "$size_hex" "$readFile"
+            else
+                echo "${2} is writable"
+                originalContent=$(mktemp)
+                echo "1. Backup the content to $originalContent"
+                readMtd "${2}" "$size_hex" "$originalContent"
+
+                echo "2. Perform read and write testing"
+                readFile=$(mktemp)
+                writeFile=$(mktemp)
+                createTestFile "$writeFile" "$size"
+                eraseMtd "${2}" "$size_hex"
+                writeMtd "${2}" "$size_hex" "$writeFile"
+                readMtd "${2}" "$size_hex" "$readFile"
+                compareFile "$writeFile" "$readFile" "${2}"
+
+                echo "3. Recover content"
+                eraseMtd "${2}" "$size_hex"
+                writeMtd "${2}" "$size_hex" "$originalContent"
+            fi
+            ;;
         count) countMtd "${2}";;
         *) echo "Need given parameter."
     esac


### PR DESCRIPTION
Before doing the read and write testing of specific MTD partition, we need to know the MTD is read-only or writable, therefore, a new variable called is_mtd_writable to help us to identify it.

The definition of **MTD_WRITEABLE** flag can reference the [mtd-utils](https://github.com/vamanea/mtd-utils/blob/bb0130e662ce6160433241e93f3fd5167a25a681/include/mtd/mtd-abi.h#L102) source code. Once the specific partition of MTD contains this bit value, it means the partition is writable.

As for the **MTD_BIT_WRITEABLE** flag, it only means the MTD can be manipulated by single bit.
Please reference [[MTD] Introduce MTD_BIT_WRITEABLE](http://www.infradead.org/pipermail/linux-mtd-cvs/2006-May/005463.html) and [mtd-utils](https://github.com/vamanea/mtd-utils/blob/bb0130e662ce6160433241e93f3fd5167a25a681/include/mtd/mtd-abi.h#L102) for more details.

There are two scenarios that we need to handle in the **compare** logic 

- If this MTD is **read-only**, I only read its content to a file.

- If this MTD is **writable**, backup its original content to a file, then do the compare procedure, finally, recover its content back.

### Test Reuslt
- KD240: https://certification.canonical.com/hardware/202304-31517/submission/313834/test-results
- Total MTD number: 17. Start from mt0 to mtd16
- Read-only MTD: mtd0, mtd1, mtd6, mtd8, mtd10, mtd11, mtd14
