### PR TITLE
Add: CAAM related test

### DIFF
--- a/checkbox-provider-ce-oem/bin/af_alg_test.py
+++ b/checkbox-provider-ce-oem/bin/af_alg_test.py
@@ -1,0 +1,238 @@
+#!/usr/bin/python3
+import socket
+import argparse
+import unittest
+import struct
+
+
+# This socket unit test is from python package /Lib/test/test_socket.py
+class LinuxKernelCryptoAPI(unittest.TestCase):
+    # tests for AF_ALG
+    def create_alg(self, typ, name):
+        sock = socket.socket(socket.AF_ALG, socket.SOCK_SEQPACKET, 0)
+        try:
+            sock.bind((typ, name))
+        except FileNotFoundError as e:
+            # type / algorithm is not available
+            sock.close()
+            print("Error: {}".format(e))
+            raise Exception(
+                "Error: Not able to use algorithm\n"
+                "Please check kernel config!"
+            )
+        else:
+            return sock
+
+    def test_sha256(self):
+        expected = bytes.fromhex(
+            "ba7816bf8f01cfea414140de5dae2223b00361a396"
+            "177a9cb410ff61f20015ad"
+        )
+        with self.create_alg("hash", "sha256") as algo:
+            op, _ = algo.accept()
+            with op:
+                op.sendall(b"abc")
+                self.assertEqual(op.recv(512), expected)
+
+            op, _ = algo.accept()
+            with op:
+                op.send(b"a", socket.MSG_MORE)
+                op.send(b"b", socket.MSG_MORE)
+                op.send(b"c", socket.MSG_MORE)
+                op.send(b"")
+                self.assertEqual(op.recv(512), expected)
+                print("hash: {}".format(op.recv(512).hex()))
+
+    def test_aes_cbc(self):
+        key = bytes.fromhex("06a9214036b8a15b512e03d534120006")
+        iv = bytes.fromhex("3dafba429d9eb430b422da802c9fac41")
+        msg = b"Single block msg"
+        ciphertext = bytes.fromhex("e353779c1079aeb82708942dbe77181a")
+        msglen = len(msg)
+        with self.create_alg("skcipher", "cbc(aes)") as algo:
+            algo.setsockopt(socket.SOL_ALG, socket.ALG_SET_KEY, key)
+            op, _ = algo.accept()
+            with op:
+                op.sendmsg_afalg(
+                    op=socket.ALG_OP_ENCRYPT, iv=iv, flags=socket.MSG_MORE
+                )
+                op.sendall(msg)
+                self.assertEqual(op.recv(msglen), ciphertext)
+
+            op, _ = algo.accept()
+            with op:
+                op.sendmsg_afalg([ciphertext], op=socket.ALG_OP_DECRYPT, iv=iv)
+                self.assertEqual(op.recv(msglen), msg)
+
+            # long message
+            multiplier = 8
+            longmsg = [msg] * multiplier
+            op, _ = algo.accept()
+            with op:
+                op.sendmsg_afalg(longmsg, op=socket.ALG_OP_ENCRYPT, iv=iv)
+                enc = op.recv(msglen * multiplier)
+            self.assertEqual(len(enc), msglen * multiplier)
+            self.assertEqual(enc[:msglen], ciphertext)
+
+            op, _ = algo.accept()
+            with op:
+                op.sendmsg_afalg([enc], op=socket.ALG_OP_DECRYPT, iv=iv)
+                dec = op.recv(msglen * multiplier)
+            self.assertEqual(len(dec), msglen * multiplier)
+            self.assertEqual(dec, msg * multiplier)
+            print("skcipher: {}".format(dec.hex()))
+
+    def test_aead_aes_gcm(self):
+        key = bytes.fromhex("c939cc13397c1d37de6ae0e1cb7c423c")
+        iv = bytes.fromhex("b3d8cc017cbb89b39e0f67e2")
+        plain = bytes.fromhex("c3b3c41f113a31b73d9a5cd432103069")
+        assoc = bytes.fromhex("24825602bd12a984e0092d3e448eda5f")
+        expected_ct = bytes.fromhex("93fe7d9e9bfd10348a5606e5cafa7354")
+        expected_tag = bytes.fromhex("0032a1dc85f1c9786925a2e71d8272dd")
+
+        taglen = len(expected_tag)
+        assoclen = len(assoc)
+        with self.create_alg("aead", "gcm(aes)") as algo:
+            algo.setsockopt(socket.SOL_ALG, socket.ALG_SET_KEY, key)
+            algo.setsockopt(
+                socket.SOL_ALG, socket.ALG_SET_AEAD_AUTHSIZE, None, taglen
+            )
+
+            # send assoc, plain and tag buffer in separate steps
+            op, _ = algo.accept()
+            with op:
+                op.sendmsg_afalg(
+                    op=socket.ALG_OP_ENCRYPT,
+                    iv=iv,
+                    assoclen=assoclen,
+                    flags=socket.MSG_MORE,
+                )
+                op.sendall(assoc, socket.MSG_MORE)
+                op.sendall(plain)
+                res = op.recv(assoclen + len(plain) + taglen)
+                self.assertEqual(expected_ct, res[assoclen:-taglen])
+                self.assertEqual(expected_tag, res[-taglen:])
+
+            # now with msg
+            op, _ = algo.accept()
+            with op:
+                msg = assoc + plain
+                op.sendmsg_afalg(
+                    [msg],
+                    op=socket.ALG_OP_ENCRYPT,
+                    iv=iv,
+                    assoclen=assoclen,
+                )
+                res = op.recv(assoclen + len(plain) + taglen)
+                self.assertEqual(expected_ct, res[assoclen:-taglen])
+                self.assertEqual(expected_tag, res[-taglen:])
+
+            # create anc data manually
+            pack_uint32 = struct.Struct("I").pack
+            op, _ = algo.accept()
+            with op:
+                msg = assoc + plain
+                op.sendmsg(
+                    [msg],
+                    (
+                        [
+                            socket.SOL_ALG,
+                            socket.ALG_SET_OP,
+                            pack_uint32(socket.ALG_OP_ENCRYPT),
+                        ],
+                        [
+                            socket.SOL_ALG,
+                            socket.ALG_SET_IV,
+                            pack_uint32(len(iv)) + iv,
+                        ],
+                        [
+                            socket.SOL_ALG,
+                            socket.ALG_SET_AEAD_ASSOCLEN,
+                            pack_uint32(assoclen),
+                        ],
+                    ),
+                )
+                res = op.recv(len(msg) + taglen)
+                self.assertEqual(expected_ct, res[assoclen:-taglen])
+                self.assertEqual(expected_tag, res[-taglen:])
+
+            # decrypt and verify
+            op, _ = algo.accept()
+            with op:
+                msg = assoc + expected_ct + expected_tag
+                op.sendmsg_afalg(
+                    [msg],
+                    op=socket.ALG_OP_DECRYPT,
+                    iv=iv,
+                    assoclen=assoclen,
+                )
+                res = op.recv(len(msg) - taglen)
+                self.assertEqual(plain, res[assoclen:])
+                print("aead: {}".format(res[assoclen:].hex()))
+
+    def test_rng(self):
+        with self.create_alg("rng", "stdrng") as algo:
+            # extra_seed = os.urandom(32)
+            # algo.setsockopt(socket.SOL_ALG, socket.ALG_SET_KEY, extra_seed)
+            op, _ = algo.accept()
+            with op:
+                rn = op.recv(32)
+                self.assertEqual(len(rn), 32)
+                print("rng: {}".format(rn.hex()))
+
+
+def get_interrupt():
+    interrupt_sum = 0
+    with open("/proc/interrupts", "r") as a:
+        data = a.readlines()
+    for line in data:
+        if ".jr" in line:
+            interrupt_sum += int(line.split()[1])
+    if not interrupt_sum:
+        raise Exception("Error: Cannot find CAAM job ring interrupts")
+    return interrupt_sum
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "type",
+        choices=["aead", "hash", "skcipher", "rng"],
+        help='AF_ALG type in "aead", "hash", "skcipher" and "rng"',
+    )
+    args = parser.parse_args()
+    rng_test = LinuxKernelCryptoAPI()
+    init_interrupt = get_interrupt()
+    print(
+        "CAAM Job ring interrupt before using Hardware RNG: {}".format(
+            init_interrupt
+        )
+    )
+    if args.type == "hash":
+        print("Starting AF_ALG type {}...".format(args.type))
+        rng_test.test_sha256()
+    elif args.type == "skcipher":
+        print("Starting AF_ALG type {}...".format(args.type))
+        rng_test.test_aes_cbc()
+    elif args.type == "aead":
+        print("Starting AF_ALG type {}...".format(args.type))
+        rng_test.test_aead_aes_gcm()
+    elif args.type == "rng":
+        print("Starting AF_ALG type {}...".format(args.type))
+        rng_test.test_rng()
+    else:
+        raise Exception("Error: non-defined AF_ALG type!")
+    current_interrupt = get_interrupt()
+    print(
+        "CAAM Job ring interrupt after using Hardware RNG: {}".format(
+            current_interrupt
+        )
+    )
+    if current_interrupt > init_interrupt:
+        print("PASS: CAAM job ring interrupts have increased.")
+    else:
+        raise Exception("FAIL: CAAM job ring interrupts didn't increase!")
+
+
+if __name__ == "__main__":
+    main()

--- a/checkbox-provider-ce-oem/units/crypto/caam.pxu
+++ b/checkbox-provider-ce-oem/units/crypto/caam.pxu
@@ -1,13 +1,3 @@
-id: cryptoinfo
-estimated_duration: 0.37
-plugin: resource
-user: root
-command: cat /proc/crypto
-requires: manifest.has_caam == 'True'
-imports: from com.canonical.plainbox import manifest
-_summary: Collect information about the crypto algorithm in system
-_description: Gets crypto algorithm resource info from /proc/crypto
-
 id: ce-oem-crypto/caam/rng-available
 _summary: Check if rng-caam is avaliable.
 plugin: shell
@@ -15,8 +5,8 @@ user: root
 category_id: caam
 flags: also-after-suspend
 estimated_duration: 1
-requires: manifest.has_caam == 'True'
-imports: from com.canonical.plainbox import manifest
+requires: 'rng-caam' in hwrng.HWRNG_Current
+imports: from com.canonical.qa.ceoem import hwrng
 command:
     hwrng_path="/sys/class/misc/hw_random/rng_current"
     echo "Hardware RNG currently using in system is: "$(cat $hwrng_path)""

--- a/checkbox-provider-ce-oem/units/crypto/caam.pxu
+++ b/checkbox-provider-ce-oem/units/crypto/caam.pxu
@@ -1,0 +1,134 @@
+id: cryptoinfo
+estimated_duration: 0.37
+plugin: resource
+user: root
+command: cat /proc/crypto
+requires: manifest.has_caam == 'True'
+imports: from com.canonical.plainbox import manifest
+_summary: Collect information about the crypto algorithm in system
+_description: Gets crypto algorithm resource info from /proc/crypto
+
+id: ce-oem-crypto/caam/rng-available
+_summary: Check if rng-caam is avaliable.
+plugin: shell
+user: root
+category_id: caam
+flags: also-after-suspend
+estimated_duration: 1
+requires: manifest.has_caam == 'True'
+imports: from com.canonical.plainbox import manifest
+command:
+    hwrng_path="/sys/class/misc/hw_random/rng_current"
+    echo "Hardware RNG currently using in system is: "$(cat $hwrng_path)""
+    if grep -q rng-caam $hwrng_path
+    then
+        echo "PASS: rng-caam is available"
+        exit 0
+    else
+        echo "FAIL: rng-caam is unavailable"
+        exit 1
+    fi
+
+id: ce-oem-crypto/caam/caam_hwrng_test
+_summary: Check if CAAM job ring increased after generate random number by using hwrng.
+plugin: shell
+user: root
+category_id: caam
+flags: also-after-suspend
+estimated_duration: 10
+depends: ce-oem-crypto/caam/rng-available
+command:
+    init_interrupt=$(awk '/\.jr/ {printf "%s ",$2;next;}' /proc/interrupts|sed 's/ //g')
+    if [ -z "$init_interrupt" ]
+    then
+        echo "ERROR: Can not find CAAM job ring interrupts"
+        exit 1
+    fi
+    echo "CAAM Job ring interrupt before using Hardware RNG: "$init_interrupt""
+    echo "Starting DD of /dev/hwrng ..."
+    dd if=/dev/hwrng bs=1M count=10 > /dev/null
+    echo "Finished DD ..."
+    interrupt=$(awk '/\.jr/ {printf "%s ",$2;next;}' /proc/interrupts|sed 's/ //g')
+    echo "CAAM Job ring interrupt after using Hardware RNG: "$interrupt""
+    if [ "$interrupt" -gt "$init_interrupt" ];
+    then
+        echo "PASS: CAAM job ring interrupts have increased."
+        exit 0
+    else
+        echo "FAIL: CAAM job ring interrupts didn't increase!"
+        exit 1
+    fi
+
+id: ce-oem-crypto/caam/algo_check
+_summary: Test CAAM algorithm is in the system
+_purpose:
+ Check if caam crypto algorithms exist in /proc/crypto
+plugin: shell
+category_id: caam
+flags: also-after-suspend fail-on-resource
+estimated_duration: 1
+requires: 'caam' in cryptoinfo.driver
+imports: from com.canonical.qa.ceoem import cryptoinfo
+command:
+    echo "PASS: Found caam algorithm"
+    echo "Please refer to resource job cryptoinfo for more detail"
+
+id: ce-oem-crypto/caam/af_alg_hash_test
+_summary: Check if CAAM job ring increased after using AF_ALG with type HASH.
+plugin: shell
+user: root
+category_id: caam
+flags: also-after-suspend
+depends: ce-oem-crypto/caam/algo_check
+estimated_duration: 10
+requires:
+    ('caam' in cryptoinfo.driver and cryptoinfo.name == 'sha256' and cryptoinfo.type == 'ahash')
+imports:
+    from com.canonical.qa.ceoem import cryptoinfo
+command:
+    af_alg_test.py hash
+
+id: ce-oem-crypto/caam/af_alg_aead_test
+_summary: Check if CAAM job ring increased after using AF_ALG with type AEAD.
+plugin: shell
+user: root
+category_id: caam
+flags: also-after-suspend
+depends: ce-oem-crypto/caam/algo_check
+estimated_duration: 10
+requires:
+    ('caam' in cryptoinfo.driver and cryptoinfo.name == 'gcm(aes)' and cryptoinfo.type == 'aead')
+imports:
+    from com.canonical.qa.ceoem import cryptoinfo
+command:
+    af_alg_test.py aead
+
+id: ce-oem-crypto/caam/af_alg_skcipher_test
+_summary: Check if CAAM job ring increased after using AF_ALG with type SKCIPHER.
+plugin: shell
+user: root
+category_id: caam
+flags: also-after-suspend
+depends: ce-oem-crypto/caam/algo_check
+estimated_duration: 10
+requires:
+    ('caam' in cryptoinfo.driver and cryptoinfo.name == 'cbc(aes)' and cryptoinfo.type == 'skcipher')
+imports:
+    from com.canonical.qa.ceoem import cryptoinfo
+command:
+    af_alg_test.py skcipher
+
+id: ce-oem-crypto/caam/af_alg_rng_test
+_summary: Check if CAAM job ring increased after using AF_ALG with type RNG.
+plugin: shell
+user: root
+category_id: caam
+flags: also-after-suspend
+depends: ce-oem-crypto/caam/algo_check
+estimated_duration: 10
+requires:
+    ('caam' in cryptoinfo.driver and cryptoinfo.name == 'stdrng' and cryptoinfo.type == 'rng')
+imports:
+    from com.canonical.qa.ceoem import cryptoinfo
+command:
+    af_alg_test.py rng

--- a/checkbox-provider-ce-oem/units/crypto/category.pxu
+++ b/checkbox-provider-ce-oem/units/crypto/category.pxu
@@ -1,0 +1,3 @@
+unit: category
+id: caam
+_name: CAAM Test

--- a/checkbox-provider-ce-oem/units/crypto/crypto_generic.pxu
+++ b/checkbox-provider-ce-oem/units/crypto/crypto_generic.pxu
@@ -1,0 +1,41 @@
+id: cryptoinfo
+estimated_duration: 1
+plugin: resource
+user: root
+command: cat /proc/crypto
+_summary: Collect information about the crypto algorithm in system
+_description: Gets crypto algorithm resource info from /proc/crypto
+
+id: hwrng
+estimated_duration: 1
+plugin: resource
+user: root
+command: 
+    path_hwrng='/sys/class/misc/hw_random/'
+    if [ -e "$path_hwrng/rng_available" ]; then
+        echo "HWRNG_Available: $(cat "$path_hwrng"rng_available)"
+    fi
+    if [ -e "$path_hwrng/rng_current" ]; then
+        echo "HWRNG_Current: $(cat "$path_hwrng"rng_current)"
+    fi        
+    if [ -e "$path_hwrng/rng_qulity" ]; then
+        echo "HWRNG_Quality: $(cat "$path_hwrng"rng_qulity)"
+    fi        
+    if [ -e "$path_hwrng/rng_selected" ]; then
+        echo "HWRNG_Selected: $(cat "$path_hwrng"rng_selected)"
+    fi        
+_summary: Collect information about the Hardware RNG in system
+
+id: ce-oem-crypto/cryptsetup_benchmark
+_summary: Measure the cryptographic performance of system
+_description: Measure the cryptographic performance of system by using cryptsetup
+plugin: shell
+user: root
+category_id: caam
+flags: also-after-suspend
+estimated_duration: 30
+command:
+    log=$(mktemp)
+    echo "Starting cryptographic benchmark testing ..."
+    cryptsetup benchmark | tee "$log"
+    awk '/aes-xts *512b/ {encryption=$3; decryption=$5} END {print "Performace of AES-XTS 512b", "\nEncryption:", encryption, "Mib/s", "\nDecryption:", decryption, "Mib/s"}' "$log"

--- a/checkbox-provider-ce-oem/units/crypto/manifest.pxu
+++ b/checkbox-provider-ce-oem/units/crypto/manifest.pxu
@@ -1,0 +1,4 @@
+unit: manifest entry
+id: has_caam
+_name: CAAM(Cryptographic Acceleration and Assurance Module) support
+value-type: bool

--- a/checkbox-provider-ce-oem/units/crypto/test-plan-caam.pxu
+++ b/checkbox-provider-ce-oem/units/crypto/test-plan-caam.pxu
@@ -19,6 +19,7 @@ _name: CAAM auto tests
 _description: Automated CAAM tests for devices
 bootstrap_include:
     cryptoinfo
+    hwrng
 include:
     ce-oem-crypto/caam/rng-available
     ce-oem-crypto/caam/caam_hwrng_test
@@ -49,6 +50,7 @@ _name: After suspend CAAM auto tests
 _description: Automated after-suspend CAAM tests for devices
 bootstrap_include:
     cryptoinfo
+    hwrng
 include:
     also-after-suspend-ce-oem-crypto/caam/rng-available
     also-after-suspend-ce-oem-crypto/caam/caam_hwrng_test

--- a/checkbox-provider-ce-oem/units/crypto/test-plan-crypto.pxu
+++ b/checkbox-provider-ce-oem/units/crypto/test-plan-crypto.pxu
@@ -1,0 +1,49 @@
+id: ce-oem-crypto-full
+unit: test plan
+_name: Crypto tests
+_description: Full crypto tests for devices
+include:
+nested_part:
+    ce-oem-crypto-manual
+    ce-oem-crypto-automated
+
+id: ce-oem-crypto-manual
+unit: test plan
+_name: Crypto manual tests
+_description: Manual crypto tests for devices
+include:
+
+id: ce-oem-crypto-automated
+unit: test plan
+_name: Crypto auto tests
+_description: Automated crypto tests for devices
+bootstrap_include:
+    cryptoinfo
+    hwrng
+include:
+    ce-oem-crypto/benchmark
+
+id: after-suspend-ce-oem-crypto-full
+unit: test plan
+_name: After suspend crypto tests
+_description: Full after-suspend crypto tests for devices
+include:
+nested_part:
+    after-suspend-ce-oem-crypto-manual
+    after-suspend-ce-oem-crypto-automated
+
+id: after-suspend-ce-oem-crypto-manual
+unit: test plan
+_name: After suspend crypto manual tests
+_description: Manual after-suspend crypto tests for devices
+include:
+
+id: after-suspend-ce-oem-crypto-automated
+unit: test plan
+_name: After suspend crypto auto tests
+_description: Automated after-suspend crypto tests for devices
+bootstrap_include:
+    cryptoinfo
+    hwrng
+include:
+    also-after-suspend-ce-oem-crypto/benchmark

--- a/checkbox-provider-ce-oem/units/crypto/test-plan.pxu
+++ b/checkbox-provider-ce-oem/units/crypto/test-plan.pxu
@@ -1,0 +1,59 @@
+id: ce-oem-caam-full
+unit: test plan
+_name: CAAM tests
+_description: Full caam tests for devices
+include:
+nested_part:
+    ce-oem-caam-manual
+    ce-oem-caam-automated
+
+id: ce-oem-caam-manual
+unit: test plan
+_name: CAAM manual tests
+_description: Manual CAAM tests for devices
+include:
+
+id: ce-oem-caam-automated
+unit: test plan
+_name: CAAM auto tests
+_description: Automated CAAM tests for devices
+bootstrap_include:
+    cryptoinfo
+include:
+    ce-oem-crypto/caam/rng-available
+    ce-oem-crypto/caam/caam_hwrng_test
+    ce-oem-crypto/caam/algo_check
+    ce-oem-crypto/caam/af_alg_hash_test
+    ce-oem-crypto/caam/af_alg_aead_test
+    ce-oem-crypto/caam/af_alg_skcipher_test
+    ce-oem-crypto/caam/af_alg_rng_test
+
+id: after-suspend-ce-oem-caam-full
+unit: test plan
+_name: After suspend CAAM tests
+_description: Full after-suspend CAAM tests for devices
+include:
+nested_part:
+    after-suspend-ce-oem-caam-manual
+    after-suspend-ce-oem-caam-automated
+
+id: after-suspend-ce-oem-caam-manual
+unit: test plan
+_name: After suspend CAAM manual tests
+_description: Manual after-suspend CAAM tests for devices
+include:
+
+id: after-suspend-ce-oem-caam-automated
+unit: test plan
+_name: After suspend CAAM auto tests
+_description: Automated after-suspend CAAM tests for devices
+bootstrap_include:
+    cryptoinfo
+include:
+    also-after-suspend-ce-oem-crypto/caam/rng-available
+    also-after-suspend-ce-oem-crypto/caam/caam_hwrng_test
+    also-after-suspend-ce-oem-crypto/caam/algo_check
+    also-after-suspend-ce-oem-crypto/caam/af_alg_hash_test
+    also-after-suspend-ce-oem-crypto/caam/af_alg_aead_test
+    also-after-suspend-ce-oem-crypto/caam/af_alg_skcipher_test
+    also-after-suspend-ce-oem-crypto/caam/af_alg_rng_test

--- a/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
+++ b/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
@@ -41,6 +41,7 @@ nested_part:
     ce-oem-eeprom-manual
     ce-oem-led-manual
     ce-oem-caam-manual
+    ce-oem-crypto-manual
 
 id: ce-oem-automated
 unit: test plan
@@ -67,6 +68,7 @@ nested_part:
     ce-oem-eeprom-automated
     ce-oem-led-automated
     ce-oem-caam-automated
+    ce-oem-crypto-automated
 
 id: after-suspend-ce-oem-manual
 unit: test plan
@@ -92,6 +94,7 @@ nested_part:
     after-suspend-ce-oem-eeprom-manual
     after-suspend-ce-oem-led-manual
     after-suspend-ce-oem-caam-manual
+    after-suspend-ce-oem-crypto-manual
 
 id: after-suspend-ce-oem-automated
 unit: test plan
@@ -116,6 +119,7 @@ nested_part:
     after-suspend-ce-oem-eeprom-automated
     after-suspend-ce-oem-led-automated
     after-suspend-ce-oem-caam-automated
+    after-suspend-ce-oem-crypto-automated
 
 id: ce-oem-stress
 unit: test plan

--- a/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
+++ b/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
@@ -40,6 +40,7 @@ nested_part:
     ce-oem-rs485-manual
     ce-oem-eeprom-manual
     ce-oem-led-manual
+    ce-oem-caam-manual
 
 id: ce-oem-automated
 unit: test plan
@@ -65,6 +66,7 @@ nested_part:
     ce-oem-rs485-automated
     ce-oem-eeprom-automated
     ce-oem-led-automated
+    ce-oem-caam-automated
 
 id: after-suspend-ce-oem-manual
 unit: test plan
@@ -89,6 +91,7 @@ nested_part:
     after-suspend-ce-oem-rs485-manual
     after-suspend-ce-oem-eeprom-manual
     after-suspend-ce-oem-led-manual
+    after-suspend-ce-oem-caam-manual
 
 id: after-suspend-ce-oem-automated
 unit: test plan
@@ -112,6 +115,7 @@ nested_part:
     after-suspend-ce-oem-rs485-automated
     after-suspend-ce-oem-eeprom-automated
     after-suspend-ce-oem-led-automated
+    after-suspend-ce-oem-caam-automated
 
 id: ce-oem-stress
 unit: test plan


### PR DESCRIPTION
Add: CAAM related test
Porting CAAM-related test jobs from project Shiner.
And made some modifications for making I/O log more useful.
sideload result without manifest:
https://pastebin.canonical.com/p/6SFGZR65Hm/
content of resource job "cryptoinfo":
https://pastebin.canonical.com/p/GvrpzgcpV9/

Add: generic crypto test
Change rng and cryptoinfo as a generic crypto test.
Add a job to use cryptsetup to test the cryptographic performance of the system.
sideload result:
https://pastebin.canonical.com/p/ywXyhgxZFH/
https://pastebin.canonical.com/p/f5dY8w6YMX/
