### PR TITLE
Fix: wrong name of after-suspend-eeprom-automated

### DIFF
--- a/checkbox-provider-ce-oem/units/eeprom/test-plan.pxu
+++ b/checkbox-provider-ce-oem/units/eeprom/test-plan.pxu
@@ -28,7 +28,7 @@ _name: EEPROM manual tests
 _description: Manual EEPROM tests for devices
 include:
 
-id: after-suspend-eeprom-automated
+id: after-suspend-ce-oem-eeprom-automated
 unit: test plan
 _name: EEPROM auto tests
 _description: Automated EEPROM tests for devices


### PR DESCRIPTION
# Description
The name of test plan `after-suspend-eeprom-automated` is wrong, it should be `after-suspend-ce-oem-eeprom-automated`