### PR TITLE
Add: add digital-io tests

### DIFF
--- a/checkbox-provider-ce-oem/bin/digital_io_loopback_serial_test.py
+++ b/checkbox-provider-ce-oem/bin/digital_io_loopback_serial_test.py
@@ -1,0 +1,152 @@
+#!/bin/python3
+import serial
+import time
+import binascii
+from argparse import ArgumentParser
+
+
+def calculate_crc(*data):
+    crc_sum = 0x00
+    for byte in data:
+        crc_sum ^= byte
+        for _ in range(0, 8):
+            tmp_int = 7 if (crc_sum & 0x80) else 0
+            crc_sum = (crc_sum << 1) ^ tmp_int
+
+            if crc_sum > 255:
+                crc_sum -= 256
+    return crc_sum
+
+
+class DigitalIOSerialController():
+
+    TEST_STATES = [0, 1]
+    # DIGITAL_IN_PINS = [6, 7, 8, 9]
+    # DIGITAL_OUT_PINS = [2, 3, 4, 5]
+    PREFIX_BYTE = 68 # equal to 0x44
+
+    def __init__(self, port):
+        self.conn = serial.Serial("/dev/{}".format(port), timeout=2)
+
+    def generate_message(self, *data):
+        """Generate command with CRC checksum
+
+        Args:
+            *data (list): paritial bytes to communicate to serial console
+
+        Returns:
+            messages (bytearray): a command to communicate to serial console
+        """
+        crc_sum = calculate_crc(*data)
+        data = list(data)
+        data.append(crc_sum)
+
+        return bytearray(data)
+
+    def read_digital_in(self, pin_num):
+        """Read the value from digital input port
+        Will issue a command to serial console with following format
+        {function_byte} {pin_byte} {crc_sum}
+
+        Args:
+            pin_num (str): the port ot DI
+
+        Returns:
+            value (str): the value of DI
+        """
+        print("\n# Read value from register byte {}..".format(pin_num))
+        msg = self.generate_message(self.PREFIX_BYTE, pin_num)
+        self.conn.write(msg)
+        resp = self.conn.read(16)
+        value = binascii.b2a_hex(resp, " ").decode("utf8").split(" ")[2]
+
+        return value
+
+    def write_digital_out(self, pin_num, value):
+        """Write th e value to digital output port
+        Will issue a command to serial console with following format
+        {function_byte} {pin_byte} {value} {crc_sum}
+
+        Args:
+            pin_num (str): the port ot DO
+            value (str): the value will write to DO
+
+        Returns:
+            N/A
+        """
+        print("\n# Write {} to register byte {}..".format(value, pin_num))
+        msg = self.generate_message(
+                  self.PREFIX_BYTE, pin_num, value)
+        self.conn.write(msg)
+        resp = self.conn.read(16)
+        print(resp)
+
+    def run_test(self, out_port, in_port):
+        """Launch Digital I/O test
+
+        Args:
+            out_port (str): the port of DO
+            in_port (str): the port of DI
+
+        Raises:
+            SystemExit: Exit the function with the test result
+        """
+        print(f"# Digital I/O loopback test. out:{out_port}, in:{in_port}")
+        raise SystemExit(not self.loopback_test(out_port, in_port))
+
+    def loopback_test(self, out_port, in_port):
+        """Launch Digital I/O loopback test
+
+        Args:
+            out_port (str): the pin byte of DO
+            in_port (str): the pin byte of DI
+
+        Returns:
+            result (bool): test results
+        """
+        result = True
+
+        for state in self.TEST_STATES:
+            value = self.read_digital_in(in_port)
+            print("Initial DI value {} is {}".format(in_port, value))
+
+            self.write_digital_out(out_port, state)
+            time.sleep(1)
+            real_state = self.read_digital_in(in_port)
+
+            if int(real_state) != state:
+                str_match = "mismatch"
+                result = False
+            else:
+                str_match = "match"
+            print("# Digital state {}. expected: {} real: {}\n".format(
+                str_match, state, real_state)
+            )
+        return result
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument(
+        "-o", "--do_byte",
+        type=int,
+        required=True,
+        help="Provide the register byte of digital output port."
+    )
+    parser.add_argument(
+        "-i", "--di_byte",
+        type=int,
+        required=True,
+        help="Provide the register byte of digital input port."
+    )
+    parser.add_argument(
+        "-s", "--serial_port",
+        required=True,
+        help="Provide the serial console port to communicate with."
+    )
+    args = parser.parse_args()
+
+    obj = DigitalIOSerialController(args.serial_port)
+    obj.run_test(args.do_byte, args.di_byte)
+
+if __name__ == "__main__":
+    main()

--- a/checkbox-provider-ce-oem/bin/digital_io_loopback_serial_test.py
+++ b/checkbox-provider-ce-oem/bin/digital_io_loopback_serial_test.py
@@ -20,7 +20,7 @@ def calculate_crc(*data):
 
 class DigitalIOSerialController():
 
-    TEST_STATES = [0, 1]
+    TEST_STATES = (0, 1)
     # DIGITAL_IN_PINS = [6, 7, 8, 9]
     # DIGITAL_OUT_PINS = [2, 3, 4, 5]
     PREFIX_BYTE = 68 # equal to 0x44
@@ -63,7 +63,7 @@ class DigitalIOSerialController():
         return value
 
     def write_digital_out(self, pin_num, value):
-        """Write th e value to digital output port
+        """Write the value to digital output port
         Will issue a command to serial console with following format
         {function_byte} {pin_byte} {value} {crc_sum}
 
@@ -91,7 +91,10 @@ class DigitalIOSerialController():
         Raises:
             SystemExit: Exit the function with the test result
         """
-        print(f"# Digital I/O loopback test. out:{out_port}, in:{in_port}")
+        print(
+            "# Digital I/O loopback test. out:{}, in:{}".format(
+                out_port, in_port)
+        )
         raise SystemExit(not self.loopback_test(out_port, in_port))
 
     def loopback_test(self, out_port, in_port):

--- a/checkbox-provider-ce-oem/bin/digital_io_loopback_test.py
+++ b/checkbox-provider-ce-oem/bin/digital_io_loopback_test.py
@@ -6,7 +6,7 @@ from argparse import ArgumentParser, RawTextHelpFormatter
 
 class DigitalIOSysFsController():
 
-    TEST_STATES = [0, 1]
+    TEST_STATES = (0, 1)
     ROOT_PATH = "/sys/class/gpio"
 
     def __init__(self):
@@ -22,7 +22,7 @@ class DigitalIOSysFsController():
         Raises:
             SystemExit: exit with the test result
         """
-        print(f"# GPIO loopback test. out:{out_port}, in:{in_port}")
+        print("# GPIO loopback test. out:{}, in:{}".format(out_port, in_port))
         raise SystemExit(not self.loopback_test(out_port, in_port))
 
     def check_gpio_node(self, port):
@@ -31,7 +31,7 @@ class DigitalIOSysFsController():
         Args:
             port (str): the gpio port
         """
-        return os.path.exists(f"{self.ROOT_PATH}/gpio{port}")
+        return os.path.exists("{}/gpio{}".format(self.ROOT_PATH, port))
 
     def set_gpio(self, port, value):
         """Write the value to GPIO port
@@ -40,9 +40,9 @@ class DigitalIOSysFsController():
             port (str): the gpio port
             value (str): 0 or 1
         """
-        print(f"# Set GPIO {port} value to {value}")
-        with open(f"{self.ROOT_PATH}/gpio{port}/value", "wt") as fp:
-            fp.write(f"{value}\n")
+        print("# Set GPIO {} value to {}".format(port, value))
+        with open("{}/gpio{}/value".format(self.ROOT_PATH, port), "wt") as fp:
+            fp.write("{}\n".format(value))
 
     def read_gpio(self, port):
         """Read the value from GPIO port
@@ -53,9 +53,9 @@ class DigitalIOSysFsController():
         Returns:
             value (str): the value of gpio port
         """
-        with open(f"{self.ROOT_PATH}/gpio{port}/value", "r") as fp:
+        with open("{}/gpio{}/value".format(self.ROOT_PATH, port), "r") as fp:
             value = fp.read().strip()
-        print(f"# Read GPIO {port}, value is {value}")
+        print("# Read GPIO {}, value is {}".format(port, value))
         return value
 
     def set_direction(self, port, value):
@@ -65,9 +65,10 @@ class DigitalIOSysFsController():
             port (str): the gpio port
             direction (str): the direction of gpio port
         """
-        print(f"# Set GPIO {port} direction to {value}")
-        with open(f"{self.ROOT_PATH}/gpio{port}/direction", "w") as fp:
-            fp.write(f"{value}\n")
+        print("# Set GPIO {} direction to {}".format(port, value))
+        with open(
+            "{}/gpio{}/direction".format(self.ROOT_PATH, port), "w") as fp:
+            fp.write("{}\n".format(value))
 
     def configure_gpio(self, port, direction):
         """Initial and configure GPIO port
@@ -82,11 +83,11 @@ class DigitalIOSysFsController():
         try:
             # Export GPIO
             if not self.check_gpio_node(port):
-                with open(f"{self.ROOT_PATH}/export", "w") as f_export:
-                    f_export.write(f"{port}\n")
+                with open("{}/export".format(self.ROOT_PATH), "w") as fexport:
+                    fexport.write("{}\n".format(port))
 
             if not self.check_gpio_node(port):
-                print(f"Failed to export GPIO {port}\n")
+                print("Failed to export GPIO {}\n".format(port))
 
             # Set direction
             self.set_direction(port, direction)

--- a/checkbox-provider-ce-oem/bin/digital_io_loopback_test.py
+++ b/checkbox-provider-ce-oem/bin/digital_io_loopback_test.py
@@ -1,0 +1,145 @@
+#!/bin/python3
+import time
+import os
+from argparse import ArgumentParser, RawTextHelpFormatter
+
+
+class DigitalIOSysFsController():
+
+    TEST_STATES = [0, 1]
+    ROOT_PATH = "/sys/class/gpio"
+
+    def __init__(self):
+        pass
+
+    def run_test(self, out_port, in_port):
+        """Launch GPIO test
+
+        Args:
+            out_port (str): the gpio port of DO
+            in_port (str): the gpio port of DI
+
+        Raises:
+            SystemExit: exit with the test result
+        """
+        print(f"# GPIO loopback test. out:{out_port}, in:{in_port}")
+        raise SystemExit(not self.loopback_test(out_port, in_port))
+
+    def check_gpio_node(self, port):
+        """Check the GPIO port is exists
+
+        Args:
+            port (str): the gpio port
+        """
+        return os.path.exists(f"{self.ROOT_PATH}/gpio{port}")
+
+    def set_gpio(self, port, value):
+        """Write the value to GPIO port
+
+        Args:
+            port (str): the gpio port
+            value (str): 0 or 1
+        """
+        print(f"# Set GPIO {port} value to {value}")
+        with open(f"{self.ROOT_PATH}/gpio{port}/value", "wt") as fp:
+            fp.write(f"{value}\n")
+
+    def read_gpio(self, port):
+        """Read the value from GPIO port
+
+        Args:
+            port (str): the gpio port
+
+        Returns:
+            value (str): the value of gpio port
+        """
+        with open(f"{self.ROOT_PATH}/gpio{port}/value", "r") as fp:
+            value = fp.read().strip()
+        print(f"# Read GPIO {port}, value is {value}")
+        return value
+
+    def set_direction(self, port, value):
+        """Set direction for GPIO port
+
+        Args:
+            port (str): the gpio port
+            direction (str): the direction of gpio port
+        """
+        print(f"# Set GPIO {port} direction to {value}")
+        with open(f"{self.ROOT_PATH}/gpio{port}/direction", "w") as fp:
+            fp.write(f"{value}\n")
+
+    def configure_gpio(self, port, direction):
+        """Initial and configure GPIO port
+
+        Args:
+            port (str): the gpio port
+            direction (str): the direction of gpio port
+
+        Raises:
+            IOError: raise error if any issue
+        """
+        try:
+            # Export GPIO
+            if not self.check_gpio_node(port):
+                with open(f"{self.ROOT_PATH}/export", "w") as f_export:
+                    f_export.write(f"{port}\n")
+
+            if not self.check_gpio_node(port):
+                print(f"Failed to export GPIO {port}\n")
+
+            # Set direction
+            self.set_direction(port, direction)
+        except Exception as err:
+            IOError("Failed to configure GPIO %s to %s", port, direction)
+
+    def loopback_test(self, out_port, in_port):
+        """Launch GPIO loopback test
+
+        Args:
+            out_port (str): the gpio port of DO
+            in_port (str): the gpio port of DI
+
+        Returns:
+            result (bool): the test result
+        """
+        result = True
+        self.configure_gpio(out_port, "out")
+        self.configure_gpio(in_port, "in")
+
+        for state in self.TEST_STATES:
+            value = self.read_gpio(in_port)
+            print("Initial GPIO {} value is {}".format(in_port, value))
+
+            self.set_gpio(out_port, state)
+            time.sleep(1)
+            real_state = self.read_gpio(in_port)
+
+            if int(real_state) != state:
+                str_match = "mismatch"
+                result = False
+            else:
+                str_match = "match"
+            print("# Digital state {}. expected: {} real: {}\n".format(
+                str_match, state, real_state)
+            )
+        return result
+
+
+def main():
+    parser = ArgumentParser(formatter_class=RawTextHelpFormatter)
+    parser.add_argument(
+        "-o", "--do_pin",
+        help="Provide the gpio pin of digital output port."
+    )
+    parser.add_argument(
+        "-i", "--di_pin",
+        help="Provide the gpio pin of digital input port."
+    )
+    args = parser.parse_args()
+
+    obj = DigitalIOSysFsController()
+    obj.run_test(args.do_pin, args.di_pin)
+
+if __name__ == "__main__":
+    main()

--- a/checkbox-provider-ce-oem/units/digital-io/category.pxu
+++ b/checkbox-provider-ce-oem/units/digital-io/category.pxu
@@ -1,0 +1,3 @@
+unit: category
+id: digital-io 
+_name: Digital I/O interface Test

--- a/checkbox-provider-ce-oem/units/digital-io/jobs.pxu
+++ b/checkbox-provider-ce-oem/units/digital-io/jobs.pxu
@@ -1,0 +1,81 @@
+id: ce-oem-digital-io/loopback_mapping_gpio
+_summary: Generates a digital I/O loopback ports mapping for digital I/O loopback test
+_description:
+    A digital I/O loopback ports mapping. By giving a pair of digital I/O port on machnie to generates test jobs.
+    Usage of parameter:
+        DIGITAL_IO_LOOPBACK_GPIO=do_port:do_gpio_pin:di_port:di_gpio_pin do_port:do_gpio_pin:di_port:di_gpio_pin ...
+    e.g. DIGITAL_IO_LOOPBACK_GPIO=1:733:2:765 3:734:4:766
+estimated_duration: 0.02
+category_id: digital-io
+plugin: resource
+environ: DIGITAL_IO_LOOPBACK_GPIO
+command:
+    awk '{
+        split($0, record, " ")
+        for (i in record) {
+            split(record[i], data, ":")
+            printf "DO: %s\nDO_GPIO: %s\nDI: %s\nDI_GPIO: %s\n\n", data[1], data[2], data[3], data[4]
+        }
+    }' <<< "$DIGITAL_IO_LOOPBACK_GPIO"
+
+unit: template
+template-resource: ce-oem-digital-io/loopback_mapping_gpio
+template-unit: job
+id: ce-oem-digital-io/loopback_gpio_DO{DO}-DI{DI}
+_summary: To test loopback between DO{DO} and DI{DI}
+plugin: shell
+user: root
+category_id: digital-io
+estimated_duration: 40s
+requires: manifest.has_digital_io == 'True'
+flags: also-after-suspend
+command:
+    echo "## Perform the digital I/O loopback test"
+    echo "DO{DO} gpio pin is {DO_GPIO}"
+    echo "DI{DI} gpio pin is {DI_GPIO}"
+    digital_io_loopback_test.py -o {DO_GPIO} -i {DI_GPIO}
+
+
+id: ce-oem-digital-io/loopback_mapping_serial
+_summary: Generates a digital I/O loopback ports mapping for digital I/O loopback test
+_description:
+    A digital I/O loopback ports mapping. By giving a pair of digital I/O port on machnie to generates test jobs.
+    Usage of parameter:
+        DIGITAL_IO_LOOPBACK_SERIAL=do_port:do_byte_pin:di_port:di_byte_pin do_port:do_byte_pin:di_port:di_byte_pin ...
+    e.g. DIGITAL_IO_LOOPBACK_SERIAL=1:2:1:6 2:3:2:7 3:4:3:8 4:5:4:9
+estimated_duration: 0.02
+category_id: digital-io
+plugin: resource
+environ: DIGITAL_IO_LOOPBACK_SERIAL
+command:
+    awk '{
+        split($0, record, " ")
+        for (i in record) {
+            split(record[i], data, ":")
+            printf "DO: %s\nDO_REGISTER_BYTE: %s\nDI: %s\nDI_REGISTER_BYTE: %s\n\n", data[1], data[2], data[3], data[4]
+        }
+    }' <<< "$DIGITAL_IO_LOOPBACK_SERIAL"
+
+unit: template
+template-resource: ce-oem-digital-io/loopback_mapping_serial
+template-unit: job
+id: ce-oem-digital-io/loopback_serial_DO{DO}-DI{DI}
+_summary: To test loopback between DO{DO} and DI{DI}
+_description:
+    The scripts will connect to the Digital IO controller via serial console
+    the serial console port is defined in variable DIGITAL_IO_CONSOLE
+plugin: shell
+user: root
+category_id: digital-io
+estimated_duration: 40s
+requires: manifest.has_digital_io == 'True'
+flags: also-after-suspend
+command:
+    if [[ -z "$DIGITAL_IO_CONSOLE" ]]; then
+        echo "DIGITAL_IO_CONSOLE variable is not defined"
+        exit 1
+    fi
+    echo "## Perform the digital I/O loopback test"
+    echo "DO{DO} register byte is {DO_REGISTER_BYTE}"
+    echo "DI{DI} register byte is {DI_REGISTER_BYTE}"
+    digital_io_loopback_serial_test.py -o {DO_REGISTER_BYTE} -i {DI_REGISTER_BYTE} -s $DIGITAL_IO_CONSOLE

--- a/checkbox-provider-ce-oem/units/digital-io/manifest.pxu
+++ b/checkbox-provider-ce-oem/units/digital-io/manifest.pxu
@@ -1,4 +1,4 @@
 unit: manifest entry
 id: has_digital_io
-_name: Does platform supported digital-io interface?
+_name: Does platform support digital-io interface?
 value-type: bool

--- a/checkbox-provider-ce-oem/units/digital-io/manifest.pxu
+++ b/checkbox-provider-ce-oem/units/digital-io/manifest.pxu
@@ -1,0 +1,4 @@
+unit: manifest entry
+id: has_digital_io
+_name: Does platform supported digital-io interface?
+value-type: bool

--- a/checkbox-provider-ce-oem/units/digital-io/test-plan.pxu
+++ b/checkbox-provider-ce-oem/units/digital-io/test-plan.pxu
@@ -1,13 +1,3 @@
-id: digital-io-full
-unit: test plan
-_name: digital-io full tests
-_description: Full digital-io tests
-include:
-    digital-io/basic-loopback-test
-    after-suspend-digital-io/basic-loopback-test
-nested_part:
-
-
 id: ce-oem-digital-io-full
 unit: test plan
 _name: Digital I/O tests
@@ -56,4 +46,3 @@ bootstrap_include:
 include:
     ce-oem-digital-io/loopback_gpio_DO.*-DI.*
     ce-oem-digital-io/loopback_serial_DO.*-DI.*
-

--- a/checkbox-provider-ce-oem/units/digital-io/test-plan.pxu
+++ b/checkbox-provider-ce-oem/units/digital-io/test-plan.pxu
@@ -1,0 +1,59 @@
+id: digital-io-full
+unit: test plan
+_name: digital-io full tests
+_description: Full digital-io tests
+include:
+    digital-io/basic-loopback-test
+    after-suspend-digital-io/basic-loopback-test
+nested_part:
+
+
+id: ce-oem-digital-io-full
+unit: test plan
+_name: Digital I/O tests
+_description: Full Digital I/O tests for devices
+include:
+nested_part:
+    ce-oem-digital-io-manual
+    ce-oem-digital-io-automated
+    after-suspend-ce-oem-digital-io-manual
+    after-suspend-ce-oem-digital-io-automated
+
+
+id: ce-oem-digital-io-manual
+unit: test plan
+_name: Digital I/O manual tests
+_description: Manual digital-io tests for devices
+include:
+
+
+id: ce-oem-digital-io-automated
+unit: test plan
+_name: Digital I/O auto tests
+_description: Automated led tests for devices
+bootstrap_include:
+    ce-oem-digital-io/loopback_mapping_gpio
+    ce-oem-digital-io/loopback_mapping_serial
+include:
+    ce-oem-digital-io/loopback_gpio_DO.*-DI.*
+    ce-oem-digital-io/loopback_serial_DO.*-DI.*
+
+
+id: after-suspend-ce-oem-digital-io-manual
+unit: test plan
+_name: Post suspend Digital I/O manual tests
+_description: Manual Digital I/O tests for devices
+include:
+
+
+id: after-suspend-ce-oem-digital-io-automated
+unit: test plan
+_name: Post suspend Digital-io auto tests
+_description: Automated digital I/O tests for devices
+bootstrap_include:
+    ce-oem-digital-io/loopback_mapping_gpio
+    ce-oem-digital-io/loopback_mapping_serial
+include:
+    ce-oem-digital-io/loopback_gpio_DO.*-DI.*
+    ce-oem-digital-io/loopback_serial_DO.*-DI.*
+


### PR DESCRIPTION
### Descriptions
Adding the loopback tests for digital IO interface.

In common practice, the digital IO will be connected to the GPIO port. But there might be some special case that the digital IO interfaces are connected to a USB to GPIO controller, so you have to control the pin by serial console.

So I have implemented two type of digital IO tests for those ports control by GPIO and serial console.

### Test result links:
- control by serial console
https://certification.canonical.com/hardware/202304-31538/submission/319323/
- control by GPIO
https://certification.canonical.com/hardware/202211-30871/submission/318757/