### PR TITLE
Fix: updated digital-io tests

### DIFF
--- a/checkbox-provider-ce-oem/units/digital-io/jobs.pxu
+++ b/checkbox-provider-ce-oem/units/digital-io/jobs.pxu
@@ -27,6 +27,7 @@ plugin: shell
 user: root
 category_id: digital-io
 estimated_duration: 40s
+imports: from com.canonical.plainbox import manifest
 requires: manifest.has_digital_io == 'True'
 flags: also-after-suspend
 command:
@@ -68,6 +69,7 @@ plugin: shell
 user: root
 category_id: digital-io
 estimated_duration: 40s
+imports: from com.canonical.plainbox import manifest
 requires: manifest.has_digital_io == 'True'
 flags: also-after-suspend
 command:

--- a/checkbox-provider-ce-oem/units/digital-io/test-plan.pxu
+++ b/checkbox-provider-ce-oem/units/digital-io/test-plan.pxu
@@ -44,5 +44,5 @@ bootstrap_include:
     ce-oem-digital-io/loopback_mapping_gpio
     ce-oem-digital-io/loopback_mapping_serial
 include:
-    ce-oem-digital-io/loopback_gpio_DO.*-DI.*
-    ce-oem-digital-io/loopback_serial_DO.*-DI.*
+    after-suspend-ce-oem-digital-io/loopback_gpio_DO.*-DI.*
+    after-suspend-ce-oem-digital-io/loopback_serial_DO.*-DI.*


### PR DESCRIPTION
- corrected digital-io tests in post-suspend stage
- import manifest job

side load test results:
WARNING:checkbox-ng.launcher.stages:Using side-loaded providers disabled the certification report
 ☑ : Hardware Manifest
 ☑ : To test loopback between DO1 and DI1
 ☑ : To test loopback between DO2 and DI2
 ☑ : To test loopback between DO3 and DI3
 ☑ : To test loopback between DO4 and DI4
 ☑ : Create resource info for supported sleep states
 ☑ : Creates resource info for RTC
 ☑ : Automated test of suspend function
 ☑ : To test loopback between DO1 and DI1 after suspend (S3)
 ☑ : To test loopback between DO2 and DI2 after suspend (S3)
 ☑ : To test loopback between DO3 and DI3 after suspend (S3)
 ☑ : To test loopback between DO4 and DI4 after suspend (S3)
