### PR TITLE
Modify CAAM and installation time related jobs.

### DIFF
--- a/checkbox-provider-ce-oem/units/crypto/caam.pxu
+++ b/checkbox-provider-ce-oem/units/crypto/caam.pxu
@@ -5,8 +5,8 @@ user: root
 category_id: caam
 flags: also-after-suspend
 estimated_duration: 1
-requires: 'rng-caam' in hwrng.HWRNG_Current
-imports: from com.canonical.qa.ceoem import hwrng
+requires: manifest.has_caam == 'True'
+imports: from com.canonical.plainbox import manifest
 command:
     hwrng_path="/sys/class/misc/hw_random/rng_current"
     echo "Hardware RNG currently using in system is: "$(cat $hwrng_path)""
@@ -50,18 +50,23 @@ command:
     fi
 
 id: ce-oem-crypto/caam/algo_check
-_summary: Test CAAM algorithm is in the system
-_purpose:
- Check if caam crypto algorithms exist in /proc/crypto
+_summary: Check CAAM algorithm is in the system /proc/crypto
 plugin: shell
 category_id: caam
-flags: also-after-suspend fail-on-resource
+flags: also-after-suspend
 estimated_duration: 1
-requires: 'caam' in cryptoinfo.driver
-imports: from com.canonical.qa.ceoem import cryptoinfo
+requires: manifest.has_caam == 'True'
+imports: from com.canonical.plainbox import manifest
 command:
-    echo "PASS: Found caam algorithm"
-    echo "Please refer to resource job cryptoinfo for more detail"
+    status=0
+    if grep -q caam /proc/crypto; then
+        echo -e "\nInfo: Found CAAM algorithm in /proc/crypto"
+    else
+        echo -e "\nError: No any CAAM algorithm has been found in /proc/crytpo"
+        status=1
+    fi
+    echo -e "\nPlease refer to resource job cryptoinfo for more detail"
+    exit "$status"
 
 id: ce-oem-crypto/caam/af_alg_hash_test
 _summary: Check if CAAM job ring increased after using AF_ALG with type HASH.

--- a/checkbox-provider-ce-oem/units/installation-time/jobs.pxu
+++ b/checkbox-provider-ce-oem/units/installation-time/jobs.pxu
@@ -1,10 +1,10 @@
+id: ce-oem-info/snapd_installation_time
 plugin: shell
 category_id: com.canonical.plainbox::info
-id: ce-oem-info/snapd_installation_time
-estimated_duration: 5
-_summary: Snapd installation time statistics via snap change log
+estimated_duration: 30
+imports: from com.canonical.certification import lsb
+requires: lsb.distributor_id == 'Ubuntu Core'
 command: installation_time.py snapd -a timing
-user: root
 _description: 
     Fetch the time of snapd change log, include 
     "Initialize system state" and "Initialize device"
@@ -26,6 +26,8 @@ category_id: com.canonical.plainbox::info
 id: ce-oem-info/cloud_init_time
 estimated_duration: 5
 _summary: Cloud init finished time statistics
+imports: from com.canonical.certification import lsb
+requires: lsb.distributor_id == 'Ubuntu Core'
 command: installation_time.py cloud-init -f cloud-init.log -a timing
 user: root
 _description: 
@@ -47,6 +49,8 @@ category_id: com.canonical.plainbox::info
 id: ce-oem-info/install_timing
 estimated_duration: 5
 _summary: Snapd installion time(seed + install system) via install timing log
+imports: from com.canonical.certification import lsb
+requires: lsb.distributor_id == 'Ubuntu Core'
 command: installation_time.py gzip-log -f install-timings.txt.gz -a timing
 user: root
 _description: 
@@ -68,6 +72,8 @@ category_id: com.canonical.plainbox::info
 id: ce-oem-info/install_mode_time
 estimated_duration: 5
 _summary: Install mode time statistics via install log
+imports: from com.canonical.certification import lsb
+requires: lsb.distributor_id == 'Ubuntu Core'
 command: installation_time.py gzip-log -f install-mode.log.gz -a timing
 user: root
 _description: 

--- a/checkbox-provider-ce-oem/units/installation-time/jobs.pxu
+++ b/checkbox-provider-ce-oem/units/installation-time/jobs.pxu
@@ -1,7 +1,8 @@
 id: ce-oem-info/snapd_installation_time
 plugin: shell
 category_id: com.canonical.plainbox::info
-estimated_duration: 30
+_summary: Snapd installation time statistics via snap change log
+estimated_duration: 5
 imports: from com.canonical.certification import lsb
 requires: lsb.distributor_id == 'Ubuntu Core'
 command: installation_time.py snapd -a timing


### PR DESCRIPTION
 Modify: modify hwrng and caam algo check to require manifest
 
 Add: requires for installation related jobs
 Make those jobs not run in Ubuntu classic and run only in Ubuntu Core
 
CAAM related jobs side load results with manifest false:
 https://pastebin.canonical.com/p/mF2pJ3MXN6/
 
CAAM related jobs side load result without manifest:
 https://pastebin.canonical.com/p/tn9VJS2Y7w/
 
Installation time related jobs side load result in Ubuntu Classic:
https://pastebin.canonical.com/p/7bvr3Xpnty/