### PR TITLE
Fix tox test environment error

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ["3.5", "3.6", "3.8"]
+        python: ["3.5", "3.6", "3.8", "3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: install stable checkbox and checkbox-provider-ce-oem

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ["3.5", "3.6", "3.8", "3.10"]
+        python: ["3.5", "3.6", "3.8"]
     steps:
       - uses: actions/checkout@v3
       - name: install stable checkbox and checkbox-provider-ce-oem

--- a/checkbox-provider-ce-oem/tox.ini
+++ b/checkbox-provider-ce-oem/tox.ini
@@ -83,4 +83,4 @@ deps =
     tqdm == 4.57.0
     pyparsing == 2.4.7
     distro == 1.7.0
-    PyYAML == 5.4.1
+    PyYAML == 6.0.1

--- a/checkbox-provider-ce-oem/tox.ini
+++ b/checkbox-provider-ce-oem/tox.ini
@@ -6,18 +6,27 @@ skipsdist=True
 [testenv]
 allowlist_externals = rm
 commands =
-    pip -q install -e ../../checkbox-ng
+    pip -q install ../../checkbox-ng
     # Required because this provider depends on checkbox-support parsers & scripts
-    pip -q install -e ../../checkbox-support
+    pip -q install ../../checkbox-support
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-resource.provider
+    rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-base.provider
+    rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-certification-client.provider
+    rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-certification-server.provider
+    rm -f /var/tmp/checkbox-providers-develop/plainbox-provider-docker.provider
+    rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-gpgpu.provider
+    rm -f /var/tmp/checkbox-providers-develop/com.canonical.certification.checkbox-provider-iiotg.provider
+    rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-sru.provider
+    rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-tpm2.provider
+    rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-ce-oem.provider
     # Install all providers in develop mode to make sure everything works fine
+    {envbindir}/python3 ../resource/manage.py develop
     {envbindir}/python3 ../base/manage.py develop
     {envbindir}/python3 ../certification-client/manage.py develop
     {envbindir}/python3 ../certification-server/manage.py develop
     {envbindir}/python3 ../docker/manage.py develop
     {envbindir}/python3 ../gpgpu/manage.py develop
     {envbindir}/python3 ../iiotg/manage.py develop
-    {envbindir}/python3 ../resource/manage.py develop
     {envbindir}/python3 ../sru/manage.py develop
     {envbindir}/python3 ../tpm2/manage.py develop
     {envbindir}/python3 manage.py develop
@@ -37,6 +46,10 @@ deps =
     pyparsing == 2.0.3
     distro == 1.0.1
     PyYAML == 3.11
+setenv=
+# we do not care about the package version in tox
+#  but it breaks some old python3.5 builds
+    SETUPTOOLS_SCM_PRETEND_VERSION=0.0
 
 [testenv:py36]
 deps =

--- a/checkbox-provider-ce-oem/tox.ini
+++ b/checkbox-provider-ce-oem/tox.ini
@@ -13,22 +13,12 @@ commands =
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-base.provider
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-certification-client.provider
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-certification-server.provider
-    rm -f /var/tmp/checkbox-providers-develop/plainbox-provider-docker.provider
-    rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-gpgpu.provider
-    rm -f /var/tmp/checkbox-providers-develop/com.canonical.certification.checkbox-provider-iiotg.provider
-    rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-sru.provider
-    rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-tpm2.provider
     rm -f /var/tmp/checkbox-providers-develop/checkbox-provider-ce-oem.provider
     # Install all providers in develop mode to make sure everything works fine
     {envbindir}/python3 ../resource/manage.py develop
     {envbindir}/python3 ../base/manage.py develop
     {envbindir}/python3 ../certification-client/manage.py develop
     {envbindir}/python3 ../certification-server/manage.py develop
-    {envbindir}/python3 ../docker/manage.py develop
-    {envbindir}/python3 ../gpgpu/manage.py develop
-    {envbindir}/python3 ../iiotg/manage.py develop
-    {envbindir}/python3 ../sru/manage.py develop
-    {envbindir}/python3 ../tpm2/manage.py develop
     {envbindir}/python3 manage.py develop
     {envbindir}/python3 manage.py validate
     {envbindir}/python3 manage.py test


### PR DESCRIPTION
Each tox test environment won't be reseted, therefore removing all providers before test is needed. After checking with checkbox repo, checkbox-ng has to use different install method to install.