### PR TITLE
Refactor cpufreq governor test

### DIFF
--- a/checkbox-provider-ce-oem/bin/cpufreq_governors.py
+++ b/checkbox-provider-ce-oem/bin/cpufreq_governors.py
@@ -771,7 +771,8 @@ def main():
 
     info = CPUScalingInfo()
     if args.policy_resource:
-        return 0 if info.print_policies_list() else 1
+        info.print_policies_list()
+        return 0
 
     if args.driver_detect:
         return 0 if info.print_scaling_drivers() else 1

--- a/checkbox-provider-ce-oem/bin/cpufreq_governors.py
+++ b/checkbox-provider-ce-oem/bin/cpufreq_governors.py
@@ -125,31 +125,6 @@ class CPUScalingInfo:
             print()
         return True
 
-    def print_scaling_drivers(self) -> bool:
-        """
-        Print the unique scaling drivers used by available CPU policies.
-
-        If there are multiple drivers, they will be listed in a
-        space-separated format. Example:
-        "scaling_driver: driver_a driver_b"
-
-        Returns:
-            bool: True if the drivers are printed successfully,
-                  False otherwise.
-        """
-        if not self.cpu_policies:
-            return False
-        drivers = []
-        for policy in self.cpu_policies:
-            driver = self.get_scaling_driver(policy)
-            if driver not in drivers:
-                drivers.append(driver)
-        if not drivers:
-            return False
-        else:
-            print("scaling_driver: {}".format(" ".join(drivers)))
-            return True
-
     def get_attribute(self, attr) -> str:
         """
         Get the value of a specific attribute from the CPU sysfs.
@@ -365,6 +340,31 @@ class CPUScalingTest:
 
         logging.info("Current Governor: %s", self.info.original_governor)
 
+    def test_driver_detect(self) -> bool:
+        """
+        Print the unique scaling drivers used by available CPU policies.
+
+        If there are multiple drivers, they will be listed in a
+        space-separated format. Example:
+        "scaling_driver: driver_a driver_b"
+
+        Returns:
+            bool: True if the drivers are printed successfully,
+                  False otherwise.
+        """
+        if not self.info.cpu_policies:
+            return False
+        drivers = []
+        for policy in self.info.cpu_policies:
+            driver = self.info.get_scaling_driver(policy)
+            if driver not in drivers:
+                drivers.append(driver)
+        if not drivers:
+            return False
+        else:
+            print("scaling_driver: {}".format(" ".join(drivers)))
+            return True
+
     def test_userspace(self) -> bool:
         """
         Run the Userspace Governor Test.
@@ -544,7 +544,7 @@ class CPUScalingTest:
 
         logging.info("Stop stressing CPUs...")
         self.stop_stress_cpus(stress_process)
-        time.sleep(5)
+        time.sleep(8)
 
         curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
         logging.debug("Current CPU frequency: %s MHz", (curr_freq / 1000))
@@ -612,7 +612,7 @@ class CPUScalingTest:
 
         logging.info("Stop stressing CPUs...")
         self.stop_stress_cpus(stress_process)
-        time.sleep(5)
+        time.sleep(8)
 
         curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
         logging.debug("Current CPU frequency: %s MHz", (curr_freq / 1000))
@@ -680,7 +680,7 @@ class CPUScalingTest:
 
         logging.info("Stop stressing CPUs...")
         self.stop_stress_cpus(stress_process)
-        time.sleep(5)
+        time.sleep(8)
 
         curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
         logging.debug("Current CPU frequency: %s MHz", (curr_freq / 1000))
@@ -774,13 +774,12 @@ def main():
         info.print_policies_list()
         return 0
 
+    test = CPUScalingTest(policy=args.policy)
     if args.driver_detect:
-        return 0 if info.print_scaling_drivers() else 1
+        return 0 if test.test_driver_detect() else 1
 
     exit_code = 0
-
     try:
-        test = CPUScalingTest(policy=args.policy)
         test.print_policy_info()
         if not getattr(test, "test_{}".format(args.governor))():
             exit_code = 1

--- a/checkbox-provider-ce-oem/bin/cpufreq_governors.py
+++ b/checkbox-provider-ce-oem/bin/cpufreq_governors.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 
-import decimal
-import os
-import re
-import sys
-import time
 import argparse
 import logging
+import os
+import re
+import subprocess
+import sys
+import time
 
+from multiprocessing import cpu_count
 from typing import List
-from subprocess import check_call, CalledProcessError
 
 
 def init_logger():
@@ -42,175 +42,130 @@ def init_logger():
     return root_logger
 
 
-class CPUScalingTest:
-    """A class for CPU scaling test operations."""
-    def __init__(self):
-        self.sys_cpu_directory = "/sys/devices/system/cpu"
-        self.cpufreq_directory = os.path.join(
-            self.sys_cpu_directory, "cpu0", "cpufreq"
-        )
-        self.min_freq = None
-        self.max_freq = None
-        self.cpufreq_directories = []
-        self.governors = []
-        self.original_governors = ""
+class CPUScalingInfo:
+    """A class for gathering CPU scaling information."""
 
-    def get_cpu_freq_directories(self):
-        """Get the path of cpufreq directories."""
-        logging.debug("Getting CPU Frequency Directories")
-        if not os.path.exists(self.sys_cpu_directory):
-            logging.error("No file %s", self.sys_cpu_directory)
-            return None
+    def __init__(self, policy=0):
+        self.sys_cpu_dir = "/sys/devices/system/cpu"
+        self.policy = policy
+        self.cpu_policies = self.get_cpu_policies()
+        self.min_freq = self.get_min_frequency()
+        self.max_freq = self.get_max_frequency()
+        self.governors = self.get_supported_governors()
+        self.original_governor = self.get_governor()
+        self.affected_cpus = self.get_affected_cpus()
 
-        # Look for cpu subdirectories
-        pattern = re.compile("cpu(?P<cpuNumber>[0-9]+)")
-        for subdirectory in os.listdir(self.sys_cpu_directory):
-            match = pattern.search(subdirectory)
-            if match and match.group("cpuNumber"):
-                cpufreq_directory = os.path.join(
-                    self.sys_cpu_directory, subdirectory, "cpufreq"
-                )
-                if not os.path.exists(cpufreq_directory):
-                    logging.error(
-                        "CPU %s has no cpufreq directory %s",
-                        match.group("cpuNumber"),
-                        cpufreq_directory,
-                    )
-                    return None
-                self.cpufreq_directories.append(cpufreq_directory)
-
-        if len(self.cpufreq_directories) == 0:
-            return None
-
-        logging.debug("Located the following CPU Freq Directories:")
-        for line in self.cpufreq_directories:
-            logging.debug("    %s", line)
-
-        return self.cpufreq_directories
-
-    def check_parameters(self, file) -> List[str]:
-        """
-        Check if parameter values from different directories are the same.
-
-        Args:
-            file (str): The name of the file to check parameters.
-
-        Returns:
-            List[str]: A list of parameter values if they are the same across
-                       directories, or an empty list if the values are not the
-                       same or an error occurs.
-        """
-        logging.debug("Checking Parameters for %s", file)
-        current = []
-        for directory in self.cpufreq_directories:
-            parameters = self.get_parameter_values(directory, file)
-            if not parameters:
-                logging.error(
-                    "Error: could not determine cpu parameters from %s",
-                    os.path.join(directory, file),
-                )
-                return []
-            if not current:
-                current = parameters
-            elif current != parameters:
-                logging.warning(
-                    "WARNING: values of %s in different cpufreq directories"
-                    "are NOT the same",
-                    file,
-                )
-                return []
-        return current
-
-    def get_parameter_values(self, cpufreq_directory, file) -> List[str]:
-        """
-        Get values of a parameter and return them as a list.
-
-        Args:
-            cpufreq_directory (str): The directory where the parameter file
-                                     is located.
-            file (str): The name of the parameter file.
-
-        Returns:
-            List[str]: A list of parameter values extracted from the file.
-
-        Example:
-            For example, if the file 'scaling_available_frequencies' contains:
-            1200000 600000 300000
-
-            The function will return:
-            ["1200000", "600000", "300000"]
-        """
-        logging.debug("Getting Parameters %s from %s", file, cpufreq_directory)
-        path = os.path.join(cpufreq_directory, file)
-        with open(path, "r", encoding="utf-8") as parameter_file:
-            for line in parameter_file:
-                line = line.strip()
-                if line:
-                    return line.split()
-        return []
-
-    def set_parameter(
-        self, set_file, read_file, value, automatch=False
-    ) -> bool:
-        """
-        Set a value to the specified set_file and verify it in the read_file.
-
-        Args:
-            set_file (str): The name of the file to set the value.
-            read_file (str): The name of the file to verify the value.
-            value: The value to be set.
-            automatch (bool, optional): If True, automatically search for the
-                                        parameter files. Defaults to False.
-
-        Returns:
-            bool: True if the value was successfully set and verified,
-                  False otherwise.
-        """
-
-        def find_parameter(target_file):
-            logging.debug("Finding parameters for %s", target_file)
-            for root, _, files in os.walk(self.sys_cpu_directory):
-                for file_name in files:
-                    file_path = os.path.join(root, file_name)
-                    if target_file in file_path:
-                        return file_path
-            return None
-
-        logging.debug("Setting %s to %s", set_file, value)
-        path = None
-        if automatch:
-            path = find_parameter(set_file)
-        else:
-            path = os.path.join(self.cpufreq_directory, set_file)
-
+    def get_cpu_policies(self) -> List:
+        path = os.path.join(self.sys_cpu_dir, "cpufreq")
         try:
-            check_call('echo "%s" > %s' % (value, path), shell=True)
-        except CalledProcessError as exception:
-            logging.exception("Command failed:")
-            logging.exception(exception)
+            policies = [
+                int(policy[6:])
+                for policy in os.listdir(path)
+                if re.match(r"policy\d+", policy)
+            ]
+        except IOError:
+            print("ERROR: Failed to get CPU policies from {}".format(path))
+            return []
+        if not policies:
+            print("ERROR: No CPU policies found in {}".format(path))
+            return []
+        return sorted(policies)
+
+    def get_scaling_driver(self, policy=0) -> str:
+        path = os.path.join(
+            self.sys_cpu_dir,
+            "cpufreq",
+            "policy{}".format(policy),
+            "scaling_driver",
+        )
+        try:
+            with open(path, "r") as attr_file:
+                line = attr_file.read()
+                return line.strip()
+        except IOError:
+            print("ERROR: Fail to get scaling driver from {}".format(path))
+            return ""
+
+    def print_policies_list(self) -> bool:
+        if not self.cpu_policies:
             return False
-
-        # verify it has changed
-        if automatch:
-            path = find_parameter(read_file)
-        else:
-            path = os.path.join(self.cpufreq_directory, read_file)
-
-        with open(path, "r", encoding="utf-8") as parameter_file:
-            line = parameter_file.readline().strip()
-            if not line or line != str(value):
-                logging.error(
-                    "Error: could not verify that %s was set to %s",
-                    path,
-                    value,
-                )
-                if line:
-                    logging.error("Actual Value: %s", line)
-                else:
-                    logging.error("parameter file was empty")
-                return False
-
+        for policy in self.cpu_policies:
+            driver = self.get_scaling_driver(policy)
+            print("policy: {}".format(policy))
+            print("scaling_driver: {}".format(driver))
+            print()
         return True
+
+    def print_scaling_drivers(self) -> bool:
+        if not self.cpu_policies:
+            return False
+        drivers = []
+        for policy in self.cpu_policies:
+            driver = self.get_scaling_driver(policy)
+            if driver not in drivers:
+                drivers.append(driver)
+        if not drivers:
+            return False
+        else:
+            print("scaling_driver: {}".format(" ".join(drivers)))
+            return True
+
+    def get_attribute(self, attr) -> str:
+        logging.debug("Getting value from attribute '%s'", attr)
+        path = os.path.join(self.sys_cpu_dir, attr)
+        try:
+            with open(path, "r") as attr_file:
+                line = attr_file.read()
+                return line.strip()
+        except IOError:
+            logging.error("Fail to get attribute from %s", path)
+            return ""
+
+    def get_policy_attribute(self, attr) -> str:
+        return self.get_attribute(
+            "cpufreq/policy{}/{}".format(self.policy, attr)
+        )
+
+    def set_attribute(self, attr, value) -> bool:
+        logging.debug("Setting value '%s' to attribute '%s'", value, attr)
+        path = os.path.join(self.sys_cpu_dir, attr)
+        try:
+            with open(path, "w") as attr_file:
+                attr_file.write(str(value))
+        except PermissionError:
+            logging.error("Permission denied when setting attribute %s", attr)
+            return False
+        except IOError:
+            logging.error("Fail to set '%s' to attribute %s", value, path)
+            return False
+        return True
+
+    def set_policy_attribute(self, attr, value) -> bool:
+        return self.set_attribute(
+            "cpufreq/policy{}/{}".format(self.policy, attr), value
+        )
+
+    def get_min_frequency(self) -> int:
+        frequency = self.get_policy_attribute("scaling_min_freq")
+        return int(frequency) if frequency else 0
+
+    def get_max_frequency(self) -> int:
+        frequency = self.get_policy_attribute("scaling_max_freq")
+        return int(frequency) if frequency else 0
+
+    def get_affected_cpus(self) -> List:
+        values = self.get_policy_attribute("affected_cpus")
+        return values.split()
+
+    def get_supported_governors(self) -> List:
+        values = self.get_policy_attribute("scaling_available_governors")
+        return values.split()
+
+    def get_governor(self) -> bool:
+        return self.get_policy_attribute("scaling_governor")
+
+    def set_governor(self, governor) -> bool:
+        return self.set_policy_attribute("scaling_governor", governor)
 
     def set_frequency(self, frequency) -> bool:
         """
@@ -224,212 +179,51 @@ class CPUScalingTest:
                   False otherwise.
         """
         logging.debug("Setting Frequency to %s", frequency)
-        return self.set_parameter(
-            "scaling_setspeed", "scaling_cur_freq", frequency
-        )
+        return self.set_policy_attribute("scaling_setspeed", frequency)
 
-    def set_governor(self, governor) -> bool:
-        """
-        Set a CPU governor to the system.
 
-        Args:
-            governor (str): The CPU governor value to be set.
+class CPUScalingTest:
+    """A class for CPU scaling test operations."""
 
-        Returns:
-            bool: True if the governor was successfully set and verified,
-                  False otherwise.
-        """
-        logging.debug("Setting Governor to %s", governor)
-        return self.set_parameter(
-            "scaling_governor", "scaling_governor", governor
-        )
+    def __init__(self, policy=0):
+        self.policy = policy
+        self.info = CPUScalingInfo(policy=self.policy)
 
-    def get_parameter_value(self, parameter) -> str:
-        """
-        Get the value of the specified parameter from cpu0/cpufreq/.
+    def stress_cpus(self) -> subprocess.Popen:
+        cpus_count = cpu_count()
 
-        Args:
-            parameter (str): The name of the parameter.
+        cmd = ["dd", "if=/dev/zero", "of=/dev/null"]
+        processes = [subprocess.Popen(cmd) for _ in range(cpus_count)]
+        return processes
 
-        Returns:
-            str or None: The parameter value as a string, or None if
-                         an error occurs.
-        """
-        logging.debug("Getting %s", parameter)
-        param_file_path = os.path.join(self.cpufreq_directory, parameter)
-        try:
-            with open(param_file_path, "r", encoding="utf-8") as param_file:
-                line = param_file.readline()
-                if not line:
-                    logging.error(
-                        "Error: failed to get %s for %s",
-                        parameter,
-                        self.cpufreq_directory,
-                    )
-                    return None
-                value = line.strip()
-                return value
-        except IOError as exception:
-            logging.exception("Error: could not open %s", param_file_path)
-            logging.exception(exception)
+    def stop_stress_cpus(self, processes):
+        for p in processes:
+            p.terminate()
+            p.wait()
 
-        return None
+    def print_policy_info(self):
+        logging.info("## CPUfreq Policy%s Info ##", self.policy)
+        logging.info("Affected CPUs:")
+        if not self.info.governors:
+            logging.info("    None")
+        else:
+            for cpu in self.info.affected_cpus:
+                logging.info("    cpu%s", cpu)
 
-    def get_parameter_list(self, parameter) -> List[str]:
-        """
-        Get the same parameter value from multiple directories.
-
-        Args:
-            parameter (str): The name of the parameter to retrieve.
-
-        Returns:
-            List[str] or None: A list of resulting parameter values if
-                               successful, or None if errors occur.
-        """
-        logging.debug("Getting parameter list")
-        values = []
-        for cpufreq_dir in self.cpufreq_directories:
-            path = os.path.join(cpufreq_dir, parameter)
-            try:
-                with open(path, "r", encoding="utf-8") as param_file:
-                    line = param_file.readline()
-                    if not line:
-                        logging.error(
-                            "Error: failed to get %s for %s",
-                            parameter,
-                            cpufreq_dir,
-                        )
-                        return None
-                    values.append(line.strip())
-            except IOError as err:
-                logging.error("Error reading file: %s", str(err))
-                return None
-
-        logging.debug("Found parameters:")
-        for line in values:
-            logging.debug("    %s", line)
-        return values
-
-    def simulate_pi(self):
-        """
-        Simulate the calculation of PI to make the CPU busy.
-
-        This function performs a series of calculations to simulate the
-        calculation of PI. It adjusts the precision, performs iterations,
-        and updates the side length, height, and number of sides.
-
-        Returns:
-            bool: Always returns True.
-        """
-        decimal.getcontext().prec = 500
-        side_length = decimal.Decimal(1)
-        height = decimal.Decimal(3).sqrt() / 2
-        num_sides = 6
-
-        for _ in range(170):
-            square_sum = (1 - height) ** 2 + side_length**2 / 4
-            side_length = square_sum.sqrt()
-            height = (1 - square_sum / 4).sqrt()
-            num_sides = 2 * num_sides
-
-        return True
-
-    def get_supported_governors(self, resource_format=False) -> bool:
-        """
-        Get the list of supported CPU governors.
-
-        Args:
-            resource_format (bool, optional): If True, print the list of
-                                              supported governors in a
-                                              resource format. Defaults
-                                              to False.
-
-        Returns:
-            bool: True if the list of supported governors is obtained
-                  successfully, False otherwise.
-        """
-        all_governors = [
-            "userspace",
-            "performance",
-            "powersave",
-            "ondemand",
-            "conservative",
-            "schedutil",
-        ]
-
-        governor_filename = "scaling_available_governors"
-        self.governors = self.check_parameters(governor_filename)
-        if not self.governors:
-            logging.error("No governor is supported")
-            return False
-
-        if resource_format:
-            scaling_driver = self.get_parameter_value("scaling_driver")
-            print("driver: {}".format(scaling_driver))
-            for governor in all_governors:
-                print(
-                    "{}: {}".format(
-                        governor,
-                        "supported"
-                        if governor in self.governors
-                        else "unsupported",
-                    )
-                )
-        return True
-
-    def get_system_capabilities(self) -> bool:
-        """
-        Retrieve and log information about the system's
-        CPU scaling capabilities.
-
-        Returns:
-            bool: True if the system capabilities were successfully retrieved
-                  and logged, False otherwise.
-        """
-        logging.info("System Capabilites:")
-        logging.info("-------------------------------------------------")
-        if len(self.cpufreq_directories) > 1:
-            logging.info("System has %u CPUs", len(self.cpufreq_directories))
-
-        # Ensure all CPUs support the same frequencies
-        freq_filename = "scaling_min_freq"
-        self.min_freq = int(self.check_parameters(freq_filename)[0])
-        if not self.min_freq:
-            return False
-        freq_filename = "scaling_max_freq"
-        self.max_freq = int(self.check_parameters(freq_filename)[0])
-        if not self.max_freq:
-            return False
         logging.info(
             "Supported CPU Frequencies: %s - %s MHz",
-            self.min_freq / 1000,
-            self.max_freq / 1000,
+            self.info.min_freq / 1000,
+            self.info.max_freq / 1000,
         )
-        # Check governors to verify all CPUs support the same control methods
-        governor_filename = "scaling_available_governors"
-        self.governors = self.check_parameters(governor_filename)
-        if not self.governors:
-            logging.error("No governor is supported")
-            return False
 
-        logging.info("Supported Governors: ")
-        for governor in self.governors:
-            logging.info("    %s", governor)
-
-        self.original_governors = self.get_parameter_list("scaling_governor")
-        if self.original_governors:
-            logging.info("Current governors:")
-            i = 0
-            for gov in self.original_governors:
-                logging.info("    cpu%u: %s", i, gov)
-                i += 1
+        logging.info("Supported Governors:")
+        if not self.info.governors:
+            logging.info("    None")
         else:
-            logging.error(
-                "Error: could not determine current governor settings"
-            )
-            return False
+            for governor in self.info.governors:
+                logging.info("    %s", governor)
 
-        return True
+        logging.info("Current Governor: %s", self.info.original_governor)
 
     def test_userspace(self) -> bool:
         """
@@ -442,45 +236,45 @@ class CPUScalingTest:
         logging.info("Running Userspace Governor Test")
         success = True
         governor = "userspace"
-        if governor not in self.governors:
+        if governor not in self.info.governors:
             logging.error("%s governor not supported", governor)
             return False
 
         logging.info("Setting governor to %s", governor)
-        if not self.set_governor(governor):
+        if not self.info.set_governor(governor):
             success = False
 
         # Set freq to minimum, verify
-        frequency = self.min_freq
+        frequency = self.info.min_freq
         logging.info(
             "Setting CPU frequency to %u MHz", (int(frequency) / 1000)
         )
-        if not self.set_frequency(frequency):
+        if not self.info.set_frequency(frequency):
             success = False
 
-        curr_freq = int(self.get_parameter_value("scaling_cur_freq"))
-        if not curr_freq or (self.min_freq != curr_freq):
+        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
+        if not curr_freq or (self.info.min_freq != curr_freq):
             logging.error(
                 "Could not verify that cpu frequency is set to the minimum"
                 " value of %s",
-                self.min_freq,
+                self.info.min_freq,
             )
             success = False
 
         # Set freq to maximum, verify
-        frequency = self.max_freq
+        frequency = self.info.max_freq
         logging.info(
             "Setting CPU frequency to %u MHz", (int(frequency) / 1000)
         )
-        if not self.set_frequency(frequency):
+        if not self.info.set_frequency(frequency):
             success = False
 
-        curr_freq = int(self.get_parameter_value("scaling_cur_freq"))
-        if not curr_freq or (self.max_freq != curr_freq):
+        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
+        if not curr_freq or (self.info.max_freq != curr_freq):
             logging.error(
                 "Could not verify that cpu frequency is set to the minimum"
                 " value of %s",
-                self.max_freq,
+                self.info.max_freq,
             )
             success = False
 
@@ -499,25 +293,27 @@ class CPUScalingTest:
         logging.info("Running Performance Governor Test")
         success = True
         governor = "performance"
-        if governor not in self.governors:
-            logging.error("%s governor not supported", governor)
+        if governor not in self.info.governors:
+            logging.error("'%s' governor not supported", governor)
             return False
 
         logging.info("Setting governor to %s", governor)
-        if not self.set_governor(governor):
+        if not self.info.set_governor(governor):
             success = False
 
-        curr_freq = int(self.get_parameter_value("scaling_cur_freq"))
+        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
         logging.debug(
-            "Verifying current frequency %s is close to max frequency",
+            "Verifying current CPU frequency %s is close to max frequency",
             curr_freq,
         )
-        if not curr_freq or (float(curr_freq) < 0.99 * float(self.max_freq)):
+        if not curr_freq or (
+            float(curr_freq) < 0.99 * float(self.info.max_freq)
+        ):
             logging.error(
                 "Current cpu frequency of %s is not close enough to the "
                 "maximum value of %s",
                 curr_freq,
-                self.max_freq,
+                self.info.max_freq,
             )
             success = False
 
@@ -536,25 +332,27 @@ class CPUScalingTest:
         logging.info("Running Powersave Governor Test")
         success = True
         governor = "powersave"
-        if governor not in self.governors:
+        if governor not in self.info.governors:
             logging.error("%s governor not supported", governor)
             return False
 
         logging.info("Setting governor to %s", governor)
-        if not self.set_governor(governor):
+        if not self.info.set_governor(governor):
             success = False
 
-        curr_freq = int(self.get_parameter_value("scaling_cur_freq"))
+        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
         logging.debug(
-            "Verifying current frequency %s is close to min frequency",
+            "Verifying current CPU frequency %s is close to min frequency",
             curr_freq,
         )
-        if not curr_freq or (float(curr_freq) * 0.99 > float(self.min_freq)):
+        if not curr_freq or (
+            float(curr_freq) * 0.99 > float(self.info.min_freq)
+        ):
             logging.error(
                 "Current cpu frequency of %s is not close enough to the "
                 "minimum value of %s",
                 curr_freq,
-                self.min_freq,
+                self.info.min_freq,
             )
             success = False
 
@@ -570,30 +368,61 @@ class CPUScalingTest:
             bool: True if the test passes, False otherwise.
         """
         logging.info("-------------------------------------------------")
-        logging.info("Running Ondemand Governor Test")
+        logging.info(
+            "Running Ondemand Governor Test on CPU policy%s", self.policy
+        )
         success = True
         governor = "ondemand"
-        if governor not in self.governors:
+        if governor not in self.info.governors:
             logging.error("%s governor not supported", governor)
             return False
 
         logging.info("Setting governor to %s", governor)
-        if not self.set_governor(governor):
+        if not self.info.set_governor(governor):
             success = False
 
-        if not self.verify_max_frequency():
+        logging.info("Stressing CPUs...")
+        stress_process = self.stress_cpus()
+        time.sleep(5)
+
+        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
+        logging.debug("Current CPU frequency: %s MHz", (curr_freq / 1000))
+        if (
+            not self.info.max_freq
+            or not curr_freq
+            or (self.info.max_freq != curr_freq)
+        ):
             logging.error(
                 "Could not verify that cpu frequency has increased to the "
                 "maximum value"
             )
             success = False
+        else:
+            logging.info(
+                "Verified current CPU frequency is equal to the max frequency"
+            )
 
-        if not self.verify_min_frequency():
+        logging.info("Stop stressing CPUs...")
+        self.stop_stress_cpus(stress_process)
+        time.sleep(5)
+
+        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
+        logging.debug("Current CPU frequency: %s MHz", (curr_freq / 1000))
+        if (
+            not self.info.min_freq
+            or not curr_freq
+            or (self.info.max_freq <= curr_freq)
+        ):
             logging.error(
-                "Could not verify that cpu frequency has settled to the "
-                "minimum value"
+                "Could not verify that cpu frequency has settled to a "
+                "lower frequency"
             )
             success = False
+        else:
+            logging.info(
+                "Verified current CPU frequency has settled to a "
+                "lower frequency"
+            )
 
         if success:
             logging.info("Ondemand Governor Test: PASS")
@@ -607,34 +436,61 @@ class CPUScalingTest:
             bool: True if the test passes, False otherwise.
         """
         logging.info("-------------------------------------------------")
-        logging.info("Running Conservative Governor Test")
+        logging.info(
+            "Running Conservative Governor Test on CPU policy%s", self.policy
+        )
         success = True
         governor = "conservative"
-        if governor not in self.governors:
+        if governor not in self.info.governors:
             logging.error("%s governor not supported", governor)
             return False
 
         logging.info("Setting governor to %s", governor)
-        if not self.set_governor(governor):
+        if not self.info.set_governor(governor):
             success = False
 
-        if not self.verify_max_frequency():
+        logging.info("Stressing CPUs...")
+        stress_process = self.stress_cpus()
+        time.sleep(5)
+
+        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
+        logging.debug("Current CPU frequency: %s MHz", (curr_freq / 1000))
+        if (
+            not self.info.max_freq
+            or not curr_freq
+            or (self.info.max_freq != curr_freq)
+        ):
             logging.error(
                 "Could not verify that cpu frequency has increased to the "
                 "maximum value"
             )
             success = False
+        else:
+            logging.info(
+                "Verified current CPU frequency is equal to the max frequency"
+            )
 
-        # Set freq_step to 20% to increase the speed of frequency up and down
-        path = os.path.join("conservative", "freq_step")
-        if not self.set_parameter(path, path, 20, automatch=True):
-            success = False
-        if not self.verify_min_frequency():
+        logging.info("Stop stressing CPUs...")
+        self.stop_stress_cpus(stress_process)
+        time.sleep(5)
+
+        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
+        logging.debug("Current CPU frequency: %s MHz", (curr_freq / 1000))
+        if (
+            not self.info.min_freq
+            or not curr_freq
+            or (self.info.max_freq <= curr_freq)
+        ):
             logging.error(
-                "Could not verify that cpu frequency has settled to the "
-                "minimum value"
+                "Could not verify that cpu frequency has settled to a "
+                "lower frequency"
             )
             success = False
+        else:
+            logging.info(
+                "Verified current CPU frequency has settled to a "
+                "lower frequency"
+            )
 
         if success:
             logging.info("Conservative Governor Test: PASS")
@@ -648,116 +504,83 @@ class CPUScalingTest:
             bool: True if the test passes, False otherwise.
         """
         logging.info("-------------------------------------------------")
-        logging.info("Running Schedutil Governor Test")
+        logging.info(
+            "Running Schedutil Governor Test on CPU policy%s", self.policy
+        )
         success = True
         governor = "schedutil"
-        if governor not in self.governors:
+        if governor not in self.info.governors:
             logging.error("%s governor not supported", governor)
             return False
 
         logging.info("Setting governor to %s", governor)
-        if not self.set_governor(governor):
+        if not self.info.set_governor(governor):
             success = False
 
-        if not self.verify_max_frequency():
+        logging.info("Stressing CPUs...")
+        stress_process = self.stress_cpus()
+        time.sleep(5)
+
+        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
+        logging.debug("Current CPU frequency: %s MHz", (curr_freq / 1000))
+        if (
+            not self.info.max_freq
+            or not curr_freq
+            or (self.info.max_freq != curr_freq)
+        ):
             logging.error(
                 "Could not verify that cpu frequency has increased to the "
                 "maximum value"
             )
             success = False
+        else:
+            logging.info(
+                "Verified current CPU frequency is equal to the max frequency"
+            )
+
+        logging.info("Stop stressing CPUs...")
+        self.stop_stress_cpus(stress_process)
+        time.sleep(5)
+
+        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
+        logging.debug("Current CPU frequency: %s MHz", (curr_freq / 1000))
+        if (
+            not self.info.min_freq
+            or not curr_freq
+            or (self.info.max_freq <= curr_freq)
+        ):
+            logging.error(
+                "Could not verify that cpu frequency has settled to a "
+                "lower frequency"
+            )
+            success = False
+        else:
+            logging.info(
+                "Verified current CPU frequency has settled to a "
+                "lower frequency"
+            )
 
         if success:
             logging.info("Schedutil Governor Test: PASS")
         return success
 
-    def verify_max_frequency(self) -> bool:
+    def restore_governor(self):
         """
-        Verify if the CPU is running at the maximum frequency
-        after performing calculations.
-
-        Returns:
-            bool: True if the CPU is running at the maximum frequency,
-                  False otherwise.
-        """
-        logging.debug("Verifying maximum frequency")
-        logging.info("Running PI calculation")
-        # Do some calculation to make CPU busy
-        self.simulate_pi()
-        logging.info("Done.")
-        curr_freq = int(self.get_parameter_value("scaling_cur_freq"))
-        logging.debug("Current CPU frequency: %s MHz", (curr_freq / 1000))
-        if not self.max_freq or not curr_freq or (self.max_freq != curr_freq):
-            return False
-        return True
-
-    def verify_min_frequency(self, wait_time=8) -> bool:
-        """
-        Verify that the CPU is operating at the minimum frequency after
-        sleeping for the specified wait_time in seconds.
-
-        Args:
-            wait_time (int, optional): The duration to sleep before checking
-                                       the CPU frequency. Defaults to 8 secs.
-
-        Returns:
-            bool: True if the CPU is operating at the minimum frequency,
-                  False otherwise.
-        """
-        logging.debug("Verifying minimum frequency")
-        logging.info("Waiting %d seconds...", wait_time)
-        time.sleep(wait_time)
-        logging.info("Done.")
-        curr_freq = int(self.get_parameter_value("scaling_cur_freq"))
-        logging.debug("Current CPU frequency: %s MHz", (curr_freq / 1000))
-        if not self.min_freq or not curr_freq or (self.min_freq != curr_freq):
-            return False
-        return True
-
-    def restore_governors(self):
-        """
-        Restore the CPU governors to their original values.
+        Restore the CPU governor to the original value.
 
         This method sets the CPU governor to the original governor value
         stored during initialization.
         """
         logging.info("-------------------------------------------------")
         logging.info(
-            "Restoring original governor to %s", (self.original_governors[0])
+            "Restoring original governor to %s",
+            self.info.original_governor
         )
-        self.set_governor(self.original_governors[0])
+        self.info.set_governor(self.info.original_governor)
 
 
 def main():
-    """
-    Run CPU Scaling Test.
-
-    This function runs a CPU scaling test based on the provided command-line
-    arguments.
-
-    Command-line Arguments:
-        -q, --quiet: Suppresses output.
-        -c, --capabilities: Only outputs CPU capabilities.
-        -d, --debug: Turns on debug level output for extra information
-                     during the test run.
-        --resource-format: Prints the capabilities in Checkbox resource job
-                           format.
-        --governor: Run a specific Governor test. Available options:
-                    'userspace', 'performance', 'powersave', 'ondemand',
-                    'conservative', 'schedutil'.
-
-    Returns:
-        int: The exit code of the test run. 0 if successful, 1 otherwise.
-    """
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "-q", "--quiet", action="store_true", help="Suppress output."
-    )
-    parser.add_argument(
-        "-c",
-        "--capabilities",
-        action="store_true",
-        help="Only output CPU capabilities.",
-    )
     parser.add_argument(
         "-d",
         "--debug",
@@ -765,9 +588,20 @@ def main():
         help="Turn on debug level output for extra info during test run.",
     )
     parser.add_argument(
-        "--resource-format",
+        "--policy-resource",
         action="store_true",
-        help="Print the capabilities in Checkbox resource job format.",
+        help="Print the polices list in Checkbox resource job format.",
+    )
+    parser.add_argument(
+        "--driver-detect",
+        action="store_true",
+        help="Print the CPU scaling driver.",
+    )
+    parser.add_argument(
+        "--policy",
+        dest="policy",
+        help="Run test on specific policy",
+        default="0",
     )
     parser.add_argument(
         "--governor",
@@ -777,37 +611,28 @@ def main():
     args = parser.parse_args()
 
     logger = init_logger()
-
     if args.debug:
         logger.setLevel(logging.DEBUG)
 
-    if args.quiet or args.resource_format:
-        # Not logging anything
-        logger.setLevel(logging.CRITICAL + 1)
+    info = CPUScalingInfo()
+    if args.policy_resource:
+        return 0 if info.print_policies_list() else 1
 
-    test = CPUScalingTest()
-    if not test.get_cpu_freq_directories():
-        logging.info("CPU Frequency Scaling not supported")
-        return 1
-
-    if args.resource_format:
-        logging.getLogger().setLevel(logging.ERROR)
-        return 0 if test.get_supported_governors(resource_format=True) else 1
-
-    if not test.get_system_capabilities():
-        logging.error("Failed to get system capabilities")
-        return 1
+    if args.driver_detect:
+        return 0 if info.print_scaling_drivers() else 1
 
     exit_code = 0
 
     try:
+        test = CPUScalingTest(policy=args.policy)
+        test.print_policy_info()
         if not getattr(test, "test_{}".format(args.governor))():
             exit_code = 1
     except AttributeError:
-        logging.error("Given governor is not supported")
+        logging.exception("Given governor is not supported")
         return 1
 
-    test.restore_governors()
+    test.restore_governor()
     return exit_code
 
 

--- a/checkbox-provider-ce-oem/bin/cpufreq_governors.py
+++ b/checkbox-provider-ce-oem/bin/cpufreq_governors.py
@@ -46,6 +46,12 @@ class CPUScalingInfo:
     """A class for gathering CPU scaling information."""
 
     def __init__(self, policy=0):
+        """
+        Initialize the CPUScalingInfo object.
+
+        Args:
+            policy (int): The CPU policy number to be used (default is 0).
+        """
         self.sys_cpu_dir = "/sys/devices/system/cpu"
         self.policy = policy
         self.cpu_policies = self.get_cpu_policies()
@@ -56,6 +62,12 @@ class CPUScalingInfo:
         self.affected_cpus = self.get_affected_cpus()
 
     def get_cpu_policies(self) -> List:
+        """
+        Get a list of available CPU policies.
+
+        Returns:
+            List: A sorted list of available CPU policy numbers.
+        """
         path = os.path.join(self.sys_cpu_dir, "cpufreq")
         try:
             policies = [
@@ -72,6 +84,15 @@ class CPUScalingInfo:
         return sorted(policies)
 
     def get_scaling_driver(self, policy=0) -> str:
+        """
+        Get the scaling driver used by a specific CPU policy.
+
+        Args:
+            policy (int): The CPU policy number to query (default is 0).
+
+        Returns:
+            str: The name of the scaling driver for the specified policy.
+        """
         path = os.path.join(
             self.sys_cpu_dir,
             "cpufreq",
@@ -87,6 +108,14 @@ class CPUScalingInfo:
             return ""
 
     def print_policies_list(self) -> bool:
+        """
+        Print the list of CPU policies and their corresponding scaling drivers
+
+        The output is in Checkbox resource job format.
+
+        Returns:
+            bool: True if the list is printed successfully, False otherwise.
+        """
         if not self.cpu_policies:
             return False
         for policy in self.cpu_policies:
@@ -97,6 +126,17 @@ class CPUScalingInfo:
         return True
 
     def print_scaling_drivers(self) -> bool:
+        """
+        Print the unique scaling drivers used by available CPU policies.
+
+        If there are multiple drivers, they will be listed in a
+        space-separated format. Example:
+        "scaling_driver: driver_a driver_b"
+
+        Returns:
+            bool: True if the drivers are printed successfully,
+                  False otherwise.
+        """
         if not self.cpu_policies:
             return False
         drivers = []
@@ -111,6 +151,15 @@ class CPUScalingInfo:
             return True
 
     def get_attribute(self, attr) -> str:
+        """
+        Get the value of a specific attribute from the CPU sysfs.
+
+        Args:
+            attr (str): The name of the attribute to query.
+
+        Returns:
+            str: The value of the specified attribute.
+        """
         logging.debug("Getting value from attribute '%s'", attr)
         path = os.path.join(self.sys_cpu_dir, attr)
         try:
@@ -122,11 +171,30 @@ class CPUScalingInfo:
             return ""
 
     def get_policy_attribute(self, attr) -> str:
+        """
+        Get the value of a specific attribute for the current CPU policy.
+
+        Args:
+            attr (str): The name of the attribute to query.
+
+        Returns:
+            str: The value of the specified attribute for the current policy.
+        """
         return self.get_attribute(
             "cpufreq/policy{}/{}".format(self.policy, attr)
         )
 
     def set_attribute(self, attr, value) -> bool:
+        """
+        Set the value of a specific attribute in the CPU sysfs.
+
+        Args:
+            attr (str): The name of the attribute to set.
+            value (str): The value to be set for the attribute.
+
+        Returns:
+            bool: True if the attribute is set successfully, False otherwise.
+        """
         logging.debug("Setting value '%s' to attribute '%s'", value, attr)
         path = os.path.join(self.sys_cpu_dir, attr)
         try:
@@ -141,41 +209,90 @@ class CPUScalingInfo:
         return True
 
     def set_policy_attribute(self, attr, value) -> bool:
+        """
+        Set the value of a specific attribute for the current CPU policy.
+
+        Args:
+            attr (str): The name of the attribute to set.
+            value (str): The value to be set for the attribute.
+
+        Returns:
+            bool: True if the attribute is set successfully, False otherwise.
+        """
         return self.set_attribute(
             "cpufreq/policy{}/{}".format(self.policy, attr), value
         )
 
     def get_min_frequency(self) -> int:
+        """
+        Get the minimum CPU frequency for the current policy.
+
+        Returns:
+            int: The minimum CPU frequency in kHz.
+        """
         frequency = self.get_policy_attribute("scaling_min_freq")
         return int(frequency) if frequency else 0
 
     def get_max_frequency(self) -> int:
+        """
+        Get the maximum CPU frequency for the current policy.
+
+        Returns:
+            int: The maximum CPU frequency in kHz.
+        """
         frequency = self.get_policy_attribute("scaling_max_freq")
         return int(frequency) if frequency else 0
 
     def get_affected_cpus(self) -> List:
+        """
+        Get the list of affected CPUs for the current policy.
+
+        Returns:
+            List: A list of affected CPUs as strings.
+        """
         values = self.get_policy_attribute("affected_cpus")
         return values.split()
 
     def get_supported_governors(self) -> List:
+        """
+        Get the list of supported governors for the current policy.
+
+        Returns:
+            List: A list of supported governors as strings.
+        """
         values = self.get_policy_attribute("scaling_available_governors")
         return values.split()
 
-    def get_governor(self) -> bool:
+    def get_governor(self) -> str:
+        """
+        Get the current governor for the current policy.
+
+        Returns:
+            str: The name of the current governor as a string.
+        """
         return self.get_policy_attribute("scaling_governor")
 
     def set_governor(self, governor) -> bool:
+        """
+        Set the governor for the current policy.
+
+        Args:
+            governor (str): The name of the governor to set.
+
+        Returns:
+            bool: True if the governor is set successfully, False otherwise.
+        """
         return self.set_policy_attribute("scaling_governor", governor)
 
     def set_frequency(self, frequency) -> bool:
         """
-        Set the CPU frequency to the specified value.
+        Set the CPU frequency for the current policy.
 
         Args:
-            frequency: The CPU frequency value to be set.
+            frequency (int): The CPU frequency value to be set in kHz.
 
         Returns:
-            bool: True if the frequency was successfully set and verified,
+            bool: True if the frequency is set and verified successfully,
                   False otherwise.
         """
         logging.debug("Setting Frequency to %s", frequency)
@@ -186,10 +303,23 @@ class CPUScalingTest:
     """A class for CPU scaling test operations."""
 
     def __init__(self, policy=0):
+        """
+        Initialize the CPUScalingTest object.
+
+        Args:
+            policy (int): The CPU policy number to be used (default is 0).
+        """
         self.policy = policy
         self.info = CPUScalingInfo(policy=self.policy)
 
     def stress_cpus(self) -> subprocess.Popen:
+        """
+        Stress the CPU cores by running multiple dd processes.
+
+        Returns:
+            subprocess.Popen: A list of Popen objects representing the
+                              dd processes spawned for each CPU core.
+        """
         cpus_count = cpu_count()
 
         cmd = ["dd", "if=/dev/zero", "of=/dev/null"]
@@ -197,11 +327,21 @@ class CPUScalingTest:
         return processes
 
     def stop_stress_cpus(self, processes):
+        """
+        Stop the CPU stress by terminating the specified dd processes.
+
+        Args:
+            processes (List[subprocess.Popen]): A list of Popen objects
+                                                representing the dd processes.
+        """
         for p in processes:
             p.terminate()
             p.wait()
 
     def print_policy_info(self):
+        """
+        Print information about the CPU frequency policy for the current CPU.
+        """
         logging.info("## CPUfreq Policy%s Info ##", self.policy)
         logging.info("Affected CPUs:")
         if not self.info.governors:
@@ -580,6 +720,21 @@ class CPUScalingTest:
 
 
 def main():
+    """
+    Execute the CPU scaling test based on the provided command-line arguments.
+
+    Command-line arguments:
+        -d, --debug: Turn on debug level output for extra info during the
+                     test run.
+        --policy-resource: Print the policies list in Checkbox resource job
+                           format.
+        --driver-detect: Print the CPU scaling driver.
+        --policy: Run the test on a specific CPU policy (default is policy 0).
+        --governor: Run a specific governor test.
+
+    Returns:
+        int: The exit code of the test execution, 0 if successful, 1 otherwise.
+    """
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "-d",

--- a/checkbox-provider-ce-oem/units/cpu/jobs.pxu
+++ b/checkbox-provider-ce-oem/units/cpu/jobs.pxu
@@ -1,14 +1,28 @@
-id: governors_list
-_summary: Collect supported scaling governors in this system
+id: cpufreq_policy_list
+_summary: List the cpufreq policies
 _description:
-    Get the capabilities of CPU scaling governors in this system
+    List the cpufreq policies with the corresponding scaling drivers
 plugin: resource
 user: root
-command: cpufreq_governors.py --resource-format
+category_id: com.canonical.plainbox::cpu
 estimated_duration: 1s
+command: cpufreq_governors.py --policy-resource
 
-id: ce-oem-cpu/cpufreq-governor-performance
-_summary: Test "performance" scaling governor
+id: ce-oem-cpu/cpufreq_driver_detect
+_summary: Detect if the CPU scaling driver exists
+plugin: shell
+user: root
+category_id: com.canonical.plainbox::cpu
+flags: also-after-suspend
+estimated_duration: 1s
+command: cpufreq_governors.py --driver-detect
+
+unit: template
+template-resource: cpufreq_policy_list
+template-unit: job
+template-filter: cpufreq_policy_list.scaling_driver != 'intel_pstate'
+id: ce-oem-cpu/cpufreq-governor-performance-policy{policy}
+_summary: Test "performance" scaling governor on policy{policy}
 _description:
     This job sets the governor to "performance" and 
     verifies whether the frequency is maximum.
@@ -17,12 +31,15 @@ user: root
 category_id: com.canonical.plainbox::cpu
 flags: also-after-suspend
 estimated_duration: 1s
-requires: governors_list.driver != 'intel_pstate'
-imports: from com.canonical.qa.ceoem import governors_list
-command: nice -n -20 cpufreq_governors.py --governor performance
+depends: ce-oem-cpu/cpufreq_driver_detect
+command: cpufreq_governors.py --policy {policy} --governor performance
 
-id: ce-oem-cpu/cpufreq-governor-powersave
-_summary: Test "powersave" scaling governor
+unit: template
+template-resource: cpufreq_policy_list
+template-unit: job
+template-filter: cpufreq_policy_list.scaling_driver != 'intel_pstate'
+id: ce-oem-cpu/cpufreq-governor-powersave-policy{policy}
+_summary: Test "powersave" scaling governor on policy{policy}
 _description:
     This job sets the governor to "powersave" and 
     verifies whether the frequency is minimum.
@@ -31,12 +48,15 @@ user: root
 category_id: com.canonical.plainbox::cpu
 flags: also-after-suspend
 estimated_duration: 1s
-requires: governors_list.driver != 'intel_pstate'
-imports: from com.canonical.qa.ceoem import governors_list
-command: nice -n -20 cpufreq_governors.py --governor powersave
+depends: ce-oem-cpu/cpufreq_driver_detect
+command: cpufreq_governors.py --policy {policy} --governor powersave
 
-id: ce-oem-cpu/cpufreq-governor-userspace
-_summary: Test "userspace" scaling governor
+unit: template
+template-resource: cpufreq_policy_list
+template-unit: job
+template-filter: cpufreq_policy_list.scaling_driver != 'intel_pstate'
+id: ce-oem-cpu/cpufreq-governor-userspace-policy{policy}
+_summary: Test "userspace" scaling governor on policy{policy}
 _description:
     This job sets the governor to "userspace" and 
     verifies the frequency when setting it to maximum
@@ -46,53 +66,62 @@ user: root
 category_id: com.canonical.plainbox::cpu
 flags: also-after-suspend
 estimated_duration: 1s
-requires: governors_list.driver != 'intel_pstate'
-imports: from com.canonical.qa.ceoem import governors_list
-command: nice -n -20 cpufreq_governors.py --governor userspace
+depends: ce-oem-cpu/cpufreq_driver_detect
+command: cpufreq_governors.py --policy {policy} --governor userspace
 
-id: ce-oem-cpu/cpufreq-governor-schedutil
-_summary: Test "schedutil" scaling governor
+unit: template
+template-resource: cpufreq_policy_list
+template-unit: job
+template-filter: cpufreq_policy_list.scaling_driver != 'intel_pstate'
+id: ce-oem-cpu/cpufreq-governor-schedutil-policy{policy}
+_summary: Test "schedutil" scaling governor on policy{policy}
 _description:
     This job sets the governor to "schedutil" and
     verifies whether the frequency will be maximum
-    after CPU doing some caculation.
+    after stressing CPUs and settling down after
+    sleeping for a few seconds.
 plugin: shell
 user: root
 category_id: com.canonical.plainbox::cpu
 flags: also-after-suspend
-estimated_duration: 3s
-requires: governors_list.driver != 'intel_pstate'
-imports: from com.canonical.qa.ceoem import governors_list
-command: nice -n -20 cpufreq_governors.py --governor schedutil
+estimated_duration: 11s
+depends: ce-oem-cpu/cpufreq_driver_detect
+command: cpufreq_governors.py --policy {policy} --governor schedutil
 
-id: ce-oem-cpu/cpufreq-governor-ondemand
-_summary: Test "ondemand" scaling governor
+unit: template
+template-resource: cpufreq_policy_list
+template-unit: job
+template-filter: cpufreq_policy_list.scaling_driver != 'intel_pstate'
+id: ce-oem-cpu/cpufreq-governor-ondemand-policy{policy}
+_summary: Test "ondemand" scaling governor on policy{policy}
 _description:
     This job sets the governor to "ondemand" and
     verifies whether the frequency will be maximum
-    after CPU doing some caculation, and minimum
-    after system sleep for a few seconds.
+    after stressing CPUs and settling down after
+    sleeping for a few seconds.
 plugin: shell
 user: root
 category_id: com.canonical.plainbox::cpu
 flags: also-after-suspend
-estimated_duration: 10s
-requires: governors_list.driver != 'intel_pstate'
-imports: from com.canonical.qa.ceoem import governors_list
-command: nice -n -20 cpufreq_governors.py --governor ondemand
+estimated_duration: 11s
+depends: ce-oem-cpu/cpufreq_driver_detect
+command: cpufreq_governors.py --policy {policy} --governor ondemand
 
-id: ce-oem-cpu/cpufreq-governor-conservative
-_summary: Test "conservative" scaling governor
+unit: template
+template-resource: cpufreq_policy_list
+template-unit: job
+template-filter: cpufreq_policy_list.scaling_driver != 'intel_pstate'
+id: ce-oem-cpu/cpufreq-governor-conservative-policy{policy}
+_summary: Test "conservative" scaling governor on policy{policy}
 _description:
     This job sets the governor to "conservative" and
     verifies whether the frequency will be maximum
-    after CPU doing some caculation, and minimum
-    after system sleep for a few seconds.
+    after stressing CPUs and settling down after
+    sleeping for a few seconds.
 plugin: shell
 user: root
 category_id: com.canonical.plainbox::cpu
 flags: also-after-suspend
-estimated_duration: 10s
-requires: governors_list.driver != 'intel_pstate'
-imports: from com.canonical.qa.ceoem import governors_list
-command: nice -n -20 cpufreq_governors.py --governor conservative
+estimated_duration: 11s
+depends: ce-oem-cpu/cpufreq_driver_detect
+command: cpufreq_governors.py --policy {policy} --governor conservative

--- a/checkbox-provider-ce-oem/units/cpu/jobs.pxu
+++ b/checkbox-provider-ce-oem/units/cpu/jobs.pxu
@@ -84,7 +84,7 @@ plugin: shell
 user: root
 category_id: com.canonical.plainbox::cpu
 flags: also-after-suspend
-estimated_duration: 11s
+estimated_duration: 14s
 depends: ce-oem-cpu/cpufreq_driver_detect
 command: cpufreq_governors.py --policy {policy} --governor schedutil
 
@@ -103,7 +103,7 @@ plugin: shell
 user: root
 category_id: com.canonical.plainbox::cpu
 flags: also-after-suspend
-estimated_duration: 11s
+estimated_duration: 14s
 depends: ce-oem-cpu/cpufreq_driver_detect
 command: cpufreq_governors.py --policy {policy} --governor ondemand
 
@@ -122,6 +122,6 @@ plugin: shell
 user: root
 category_id: com.canonical.plainbox::cpu
 flags: also-after-suspend
-estimated_duration: 11s
+estimated_duration: 14s
 depends: ce-oem-cpu/cpufreq_driver_detect
 command: cpufreq_governors.py --policy {policy} --governor conservative

--- a/checkbox-provider-ce-oem/units/cpu/test-plan.pxu
+++ b/checkbox-provider-ce-oem/units/cpu/test-plan.pxu
@@ -21,14 +21,15 @@ unit: test plan
 _name: CPU auto tests
 _description: Automated CPU tests for devices
 bootstrap_include:
-    governors_list
+    cpufreq_policy_list
 include:
-    ce-oem-cpu/cpufreq-governor-performance
-    ce-oem-cpu/cpufreq-governor-powersave
-    ce-oem-cpu/cpufreq-governor-userspace
-    ce-oem-cpu/cpufreq-governor-schedutil
-    ce-oem-cpu/cpufreq-governor-ondemand
-    ce-oem-cpu/cpufreq-governor-conservative
+    ce-oem-cpu/cpufreq_driver_detect
+    ce-oem-cpu/cpufreq-governor-performance-.*
+    ce-oem-cpu/cpufreq-governor-powersave-.*
+    ce-oem-cpu/cpufreq-governor-userspace-.*
+    ce-oem-cpu/cpufreq-governor-schedutil-.*
+    ce-oem-cpu/cpufreq-governor-ondemand-.*
+    ce-oem-cpu/cpufreq-governor-conservative-.*
 
 id: after-suspend-ce-oem-cpu-manual
 unit: test plan
@@ -42,12 +43,12 @@ unit: test plan
 _name: CPU auto tests
 _description: Automated after suspend CPU tests for devices
 bootstrap_include:
-    governors_list
+    cpufreq_policy_list
 include:
-    after-suspend-ce-oem-cpu/offlining_test
-    after-suspend-ce-oem-cpu/cpufreq-governor-performance
-    after-suspend-ce-oem-cpu/cpufreq-governor-powersave
-    after-suspend-ce-oem-cpu/cpufreq-governor-userspace
-    after-suspend-ce-oem-cpu/cpufreq-governor-schedutil
-    after-suspend-ce-oem-cpu/cpufreq-governor-ondemand
-    after-suspend-ce-oem-cpu/cpufreq-governor-conservative
+    after-suspend-ce-oem-cpu/cpufreq_driver_detect
+    after-suspend-ce-oem-cpu/cpufreq-governor-performance-.*
+    after-suspend-ce-oem-cpu/cpufreq-governor-powersave-.*
+    after-suspend-ce-oem-cpu/cpufreq-governor-userspace-.*
+    after-suspend-ce-oem-cpu/cpufreq-governor-schedutil-.*
+    after-suspend-ce-oem-cpu/cpufreq-governor-ondemand-.*
+    after-suspend-ce-oem-cpu/cpufreq-governor-conservative-.*


### PR DESCRIPTION
Task: https://warthogs.atlassian.net/browse/CQT-2906

The original script didn't handle the machine that doesn't enable the cpufreq feature well and didn't consider the machine with multiple policies. Therefore, this pull request refactors the script to policy-based tests.

### Jobs
* The `cpufreq_policy_list` resource job lists the CPU policies in the system and their corresponding scaling drivers.
* The `ce-oem-cpu/cpufreq_driver_detect` is to detect if the scaling drivers exist. It can be run on both ARM and Intel platforms.
* The `ce-oem-cpu/cpufreq-governor-.*-policy.*` jobs will only be generated when the scaling driver is not `intel_pstate`. And they also depend on `ce-oem-cpu/cpufreq_driver_detect`, which means if the scaling driver doesn't exist (fail), these jobs will be skipped.

### Structure
* Class `CPUScalingInfo` gathers the needed CPU scaling information.
* Class `CPUScalingTest` contains the tests for all 6 governors.
* The test steps for governor `performance`, `powersave`, and `userspace` didn't change.
* The test steps for governor `ondemand`, `conservative`, and `schedutil` are streamlined to:
  1. Set the governor
  2. Stress the CPUs for 5 seconds
  3. Get the current CPU frequency
  4. Check whether the frequency is equal to the max frequency
  5. Kill the process that stressed the CPUs and sleep 5 seconds
  6. Get the current CPU frequency
  7. Check whether the frequency is lower than the max frequency

### Resource job output:
https://pastebin.canonical.com/p/wSjC82rMf8/

### Sideload results on different machines:
* On Baytown project, which has 2 cpus (cpu0, cpu1) for 1 policy (policy0)
https://pastebin.canonical.com/p/KtqPYMZDfM/
* On Baoshan project, which has 8 cpus (cpu0~7) and 2 policies (policy0, policy4)
https://pastebin.canonical.com/p/D53Rj7ZVsv/
* On a laptop using intel CPU
https://pastebin.canonical.com/p/knsyD6XtTJ/