### PR TITLE
Change: PTP command

### DIFF
--- a/checkbox-provider-ce-oem/units/ptp/jobs.pxu
+++ b/checkbox-provider-ce-oem/units/ptp/jobs.pxu
@@ -86,6 +86,9 @@ depends: ce-oem-ptp/verify-PTP-support-for-{eth-interface}
 command:
     output_file='/var/tmp/ptp4l_output.txt'
     echo "Executing ptp4l for 30s"
+    # Add --tx_timstamp_timeout=5 due to the patch of ptp4l increace from 1 to 5ms.
+    # https://www.mail-archive.com/linuxptp-devel@lists.sourceforge.net/msg05015.html
+    # And this patch has been merged into the versoin later then V2.0
     (set -x; timeout 30s ptp4l -i {eth-interface} -m -s --network_transport=L2 --tx_timestamp_timeout=5 | tee $output_file)
     rms_data=$(tail -5 $output_file | awk '/rms/{{print $3}}')
     if [[ -z $rms_data ]]; then

--- a/checkbox-provider-ce-oem/units/ptp/jobs.pxu
+++ b/checkbox-provider-ce-oem/units/ptp/jobs.pxu
@@ -86,7 +86,7 @@ depends: ce-oem-ptp/verify-PTP-support-for-{eth-interface}
 command:
     output_file='/var/tmp/ptp4l_output.txt'
     echo "Executing ptp4l for 30s"
-    (set -x; timeout 30s ptp4l -i {eth-interface} -m -s --network_transport=L2 | tee $output_file)
+    (set -x; timeout 30s ptp4l -i {eth-interface} -m -s --network_transport=L2 --tx_timestamp_timeout=5 | tee $output_file)
     rms_data=$(tail -5 $output_file | awk '/rms/{{print $3}}')
     if [[ -z $rms_data ]]; then
         echo "ERROR: unable to get rms value from the output file"
@@ -125,7 +125,7 @@ _steps:
        $ sudo ./ptp4l -i <if_name_on_host> -m --step_threshold=1 --logAnnounceInterval=0 --logSyncInterval=-3 --network_transport=L2
     3. Wait for the system to announce it is the Grand Master.
     4. On the DUT, run the command:
-       $ sudo ./ptp4l -i {eth-interface} -m -s --network_transport=L2
+       $ sudo ./ptp4l -i {eth-interface} -m -s --network_transport=L2 --tx_timestamp_timeout=5
     5. The DUT should announce it has selected a foreign master (Host)
     6. Clock readings will appear on the DUT.  When the "rms" value remains below 100ns, 
        the DUT has successfully synchronized to the clock on the Host.


### PR DESCRIPTION
lp:2030942, workaround for the current version of ptp4l, and we will try to build the latest version in checkbox-ce-oem in the future.
https://bugs.launchpad.net/shiner/+bug/2030942

Sideload result with x8high-pdk. PDK has two different ETH PHY, and both works fine.
https://certification.canonical.com/hardware/202304-31534/submission/327076/test-results/pass/

The result on Ti AM62:
root@am62xx-evm:~# ./ptp4l -i eth1 -m -s --network_transport=L2 --tx_timestamp_timeout=5
ptp4l[7863.164]: selected /dev/ptp0 as PTP clock
ptp4l[7863.225]: port 1: INITIALIZING to LISTENING on INIT_COMPLETE
ptp4l[7863.226]: port 0: INITIALIZING to LISTENING on INIT_COMPLETE
ptp4l[7863.700]: port 1: new foreign master a44cc8.fffe.2b5c7d-1
ptp4l[7865.700]: selected best master clock a44cc8.fffe.2b5c7d
ptp4l[7865.701]: running in a temporal vortex
ptp4l[7865.701]: port 1: LISTENING to UNCALIBRATED on RS_SLAVE
ptp4l[7866.628]: port 1: UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED
ptp4l[7867.254]: rms 846163223650296704 max 1692326447300593408 freq -11017 +/- 6526 delay 22638 +/-   0
ptp4l[7868.257]: rms 2129 max 4380 freq  -8977 +/- 2033 delay 22572 +/-   0
ptp4l[7869.260]: rms 1609 max 2267 freq  -4571 +/- 953
ptp4l[7870.263]: rms 1436 max 1878 freq  -3106 +/- 360 delay 22638 +/-   0
ptp4l[7871.265]: rms  467 max  830 freq  -3737 +/- 459 delay 22671 +/-   0
ptp4l[7872.267]: rms  487 max  877 freq  -3520 +/- 569 delay 22638 +/-   0
ptp4l[7873.270]: rms  292 max  520 freq  -4113 +/- 309 delay 22688 +/-  17
ptp4l[7874.272]: rms  318 max  584 freq  -3918 +/- 436 delay 22717 +/-   0
ptp4l[7875.275]: rms  443 max  800 freq  -4391 +/- 515
ptp4l[7876.278]: rms  413 max  641 freq  -3680 +/- 441 delay 22711 +/-   6
ptp4l[7877.280]: rms  282 max  596 freq  -3880 +/- 389


The result on MTK:
ubuntu@mtk-genio:~$ sudo ./ptp4l -i eth0 -m -s --network_transport=L2 --tx_timestamp_timeout=5
ptp4l[93183.587]: selected /dev/ptp0 as PTP clock
ptp4l[93183.681]: port 1: INITIALIZING to LISTENING on INIT_COMPLETE
ptp4l[93183.681]: port 0: INITIALIZING to LISTENING on INIT_COMPLETE
ptp4l[93184.027]: port 1: new foreign master a44cc8.fffe.2b5c7d-1
ptp4l[93186.029]: selected best master clock a44cc8.fffe.2b5c7d
ptp4l[93186.029]: running in a temporal vortex
ptp4l[93186.029]: port 1: LISTENING to UNCALIBRATED on RS_SLAVE
ptp4l[93187.372]: port 1: UNCALIBRATED to SLAVE on MASTER_CLOCK_SELECTED
ptp4l[93187.998]: rms 262393811943616 max 524787623887885 freq  +7133 +/- 2966 delay 22013 +/-   0
ptp4l[93189.001]: rms 1706 max 2578 freq  +6044 +/- 513
ptp4l[93190.004]: rms  928 max 1378 freq  +5896 +/- 452 delay 21939 +/-   0
ptp4l[93191.007]: rms  358 max  552 freq  +6168 +/- 333
ptp4l[93192.009]: rms  337 max  601 freq  +6728 +/- 397 delay 21977 +/-   0
ptp4l[93193.012]: rms  260 max  469 freq  +6678 +/- 351 delay 21995 +/-   0
ptp4l[93194.015]: rms  409 max  680 freq  +6932 +/- 521
ptp4l[93195.017]: rms  215 max  387 freq  +6703 +/- 287 delay 22013 +/-   0
ptp4l[93196.020]: rms  299 max  660 freq  +6652 +/- 409 delay 22014 +/-   0
ptp4l[93197.024]: rms  202 max  306 freq  +6821 +/- 255
ptp4l[93198.026]: rms  190 max  279 freq  +6685 +/- 258 delay 22026 +/-  12
ptp4l[93199.029]: rms  363 max  669 freq  +6794 +/- 499 delay 22014 +/-   0
ptp4l[93200.032]: rms  319 max  502 freq  +6620 +/- 435 delay 22039 +/-   0
ptp4l[93201.033]: rms  452 max  796 freq  +6413 +/- 596
