### PR TITLE
Update ptp tests

### DIFF
--- a/checkbox-provider-ce-oem/units/ptp/jobs.pxu
+++ b/checkbox-provider-ce-oem/units/ptp/jobs.pxu
@@ -9,9 +9,9 @@ user: root
 estimated_duration: 2s
 flags: preserve-locale
 command:
-    KEYWORDS="SOF_TIMESTAMPING_RAW_HARDWARE
-              SOF_TIMESTAMPING_TX_HARDWARE
-              SOF_TIMESTAMPING_RX_HARDWARE"
+    KEYWORDS="hardware-transmit
+              hardware-receive
+              hardware-raw-clock"
     for iface in /sys/class/net/*; do
         iface=${iface##*/}
         supported=true

--- a/checkbox-provider-ce-oem/units/ptp/test-plan.pxu
+++ b/checkbox-provider-ce-oem/units/ptp/test-plan.pxu
@@ -12,7 +12,11 @@ nested_part:
 id: ce-oem-ptp-manual
 unit: test plan
 _name: PTP manual tests
-_description: Manual PTP tests for devices
+_description:
+    Manual PTP tests for devices
+    This is not nested in ce-oem-manual because the current
+    test job steps are duplicated with the auto test job.
+    The manual test steps here is used as a reference.
 bootstrap_include:
     ce-oem-ptp/ptp-devices
 include:
@@ -31,7 +35,11 @@ include:
 id: after-suspend-ce-oem-ptp-manual
 unit: test plan
 _name: After suspend PTP manual tests
-_description: Manual after suspend PTP tests for devices
+_description:
+    Manual after suspend PTP tests for devices
+    This is not nested in after-suspend-ce-oem-manual because
+    the current test job steps are duplicated with the auto test job.
+    The manual test steps here is used as a reference.
 bootstrap_include:
     ce-oem-ptp/ptp-devices
 include:

--- a/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
+++ b/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
@@ -29,7 +29,6 @@ nested_part:
     ce-oem-installation-info-manual
     ce-oem-cpu-manual
     ce-oem-button-manual
-    ce-oem-ptp-manual
     ce-oem-sensor-manual
     ce-oem-gps-manual
     ce-oem-mtd-manual
@@ -86,7 +85,6 @@ include:
 nested_part:
     after-suspend-ce-oem-cpu-manual
     after-suspend-ce-oem-button-manual
-    after-suspend-ce-oem-ptp-manual
     after-suspend-ce-oem-sensor-manual
     after-suspend-ce-oem-gps-manual
     after-suspend-ce-oem-mtd-manual


### PR DESCRIPTION
Jira task: https://warthogs.atlassian.net/browse/CQT-3259

* Change: hardware PTP support keywords
    
    For PTP capabilities, ethtool v5.4 (on Ubuntu 20.04) shows
    `hardware-transmit     (SOF_TIMESTAMPING_TX_HARDWARE)`
    But ethtool v5.16 (on Ubuntu 22.04) only shows
    `hardware-transmit`
    
    The test case was using `SOF_TIMESTAMPING_TX_HARDWARE` as keywords,
    This commit changes it to use `hardware-transmit` for adapting new
    version of ethtool.

* Remove: nested ptp-manual test plans
    
    The current manual test job steps are duplicated with the auto test job.
    Currently we only need to run the auto test job.
    The manual test steps here is used as a reference.
    If there are new jobs in th future, the ptp-manual test plan can be
    nested back.


## Sideload results
* Running on a ubuntu 20.04 laptop
https://pastebin.canonical.com/p/YJgJVfPZZd/
* Running on a Ubuntu 22.04 IoT device
https://pastebin.canonical.com/p/S84jt6pCHT/