### PR TITLE
Modify optee test run out of gadget

### DIFF
--- a/checkbox-provider-ce-oem/units/optee/README.md
+++ b/checkbox-provider-ce-oem/units/optee/README.md
@@ -1,42 +1,40 @@
-# This is a file to introducing OP-TEE(Open Source - Trusted Execution Environment) test jobs.
+# Introduction to OP-TEE (Open Source - Trusted Execution Environment) Test Jobs
 
 ## id: ce-oem-optee/device-node
-  This job will check if OP-TEE node (teepriv0 and tee0) have been probed.
-  And it relies on the manifest "has_optee" to be true.
+This job checks if the OP-TEE node (teepriv0 and tee0) has been probed.
+It relies on the manifest "has_optee" to be true.
 
 ## id: ce-oem-optee/xtest-check
-  This job will check if xtest is in gadget snap. Since xtest and TA rely on the same signing key with optee-os and optee-client. Therefore, xtest will be build-in in gadget snap.
-  However, if you intend to use your own build optee-test, you can assign the checkbox config variable to make this job to use specific tool.
-  Checkbox config variable "OPTEE_TOOL" should be gaven a full applications name.
-  Includes SNAP name and APP name if it as a SNAP, otherwise the the APP name should be fine.
-  e.g. SNAP named "optee-test" and APP name "xtest".
-    OPTEE_TOOL=optee-test.xtest
-  e.g. APP named "xtest".
-    OPTEE_TOOL=xtest
+This job checks if xtest is in the gadget snap. Since xtest and TA (Trusted Application) rely on the same signing key as optee-os and optee-client, xtest is built into the gadget snap.
+However, if you intend to use your own built optee-test, you can assign the checkbox config variable to make this job use a specific tool.
+The checkbox config variable "OPTEE_TOOL" should be given the full application name, including SNAP name and APP name if it's a SNAP, otherwise, the APP name should be fine.
+For example:
+- SNAP named "optee-test" and APP name "xtest": `OPTEE_TOOL=optee-test.xtest`
+- APP named "xtest": `OPTEE_TOOL=xtest`
 
 ## id: ce-oem-optee-test-list
-  This is a resource job will generate a list of the optee-test agenest the optee-test.json.(Please check the section about *Test cases for optee-test*).
-  And it will be include *regression* and *benchmark* of optee-test.
-  The checkbox config variable "OPTEE_CASES" allows you to give a path of *optee-test.json* if needed. Otherwise, it will use the default JSON file in the provier.
-  Please make sure the file can be accessed by checkbox.
-  e.g. OPTEE_CASES=/home/user/optee-test.json
+This resource job generates a list of optee-test against optee-test.json (Please check the section about "Test cases for optee-test").
+It includes "regression" and "benchmark" tests of optee-test.
+The checkbox config variable "OPTEE_CASES" allows you to provide a path to optee-test.json if needed. Otherwise, it will use the default JSON file in the provider.
+Please ensure that the file can be accessed by checkbox.
+For example: `OPTEE_CASES=/home/user/optee-test.json`
 
 ## id: ce-oem-optee-test-list-pkcs11
-  This is a resource job will generate a list of the optee-test agenest the optee-test.json.(Please check the section about *Test cases for optee-test*).
-  And it will be include *pkcs11* of optee-test.
-  The checkbox config variable "OPTEE_CASES" allows you to give a path of *optee-test.json* if needed. Otherwise, it will use the default JSON file in the provier.
-  Please make sure the file can be accessed by checkbox.
-  e.g. OPTEE_CASES=/home/user/optee-test.json
+This resource job generates a list of optee-test against optee-test.json (Please check the section about "Test cases for optee-test").
+It includes the "pkcs11" test of optee-test.
+The checkbox config variable "OPTEE_CASES" allows you to provide a path to optee-test.json if needed. Otherwise, it will use the default JSON file in the provider.
+Please ensure that the file can be accessed by checkbox.
+For example: `OPTEE_CASES=/home/user/optee-test.json`
 
-## Test coverage
-  We have covered the default tests of optee-test, which include: 
-  - Benchmark
-  - Regression
-  - PKCS11
-  
-  For the *Benchmark* and *Regression* tests, TA (Trusted Applications) need to be installed before the test
+## Test Coverage
+We have covered the default tests of optee-test, which include:
+- Benchmark
+- Regression
+- PKCS11
 
-  For the *PKCS11* tests, there are no specific requirements.
+For the "Benchmark" and "Regression" tests, Trusted Applications (TA) need to be installed before the test.
 
-## Test cases for optee-test (optee-test.json)
-  We parse the source of xtest that in optee-test. And dump it into *optee-test.json*. And we have a [python script](https://git.launchpad.net/~rickwu4444/+git/tools/tree/parse_optee_test_cases) to do it offline. 
+For the "PKCS11" tests, there are no specific requirements.
+
+## Test Cases for optee-test (optee-test.json)
+We parse the source of xtest within optee-test and dump it into "optee-test.json." We have a [Python script](https://git.launchpad.net/~rickwu4444/+git/tools/tree/parse_optee_test_cases) to perform this task offline.

--- a/checkbox-provider-ce-oem/units/optee/README.md
+++ b/checkbox-provider-ce-oem/units/optee/README.md
@@ -6,7 +6,28 @@
 
 ## id: ce-oem-optee/xtest-check
   This job will check if xtest is in gadget snap. Since xtest and TA rely on the same signing key with optee-os and optee-client. Therefore, xtest will be build-in in gadget snap.
-  
+  However, if you intend to use your own build optee-test, you can assign the checkbox config variable to make this job to use specific tool.
+  Checkbox config variable "OPTEE_TOOL" should be gaven a full applications name.
+  Includes SNAP name and APP name if it as a SNAP, otherwise the the APP name should be fine.
+  e.g. SNAP named "optee-test" and APP name "xtest".
+    OPTEE_TOOL=optee-test.xtest
+  e.g. APP named "xtest".
+    OPTEE_TOOL=xtest
+
+## id: ce-oem-optee-test-list
+  This is a resource job will generate a list of the optee-test agenest the optee-test.json.(Please check the section about *Test cases for optee-test*).
+  And it will be include *regression* and *benchmark* of optee-test.
+  The checkbox config variable "OPTEE_CASES" allows you to give a path of *optee-test.json* if needed. Otherwise, it will use the default JSON file in the provier.
+  Please make sure the file can be accessed by checkbox.
+  e.g. OPTEE_CASES=/home/user/optee-test.json
+
+## id: ce-oem-optee-test-list-pkcs11
+  This is a resource job will generate a list of the optee-test agenest the optee-test.json.(Please check the section about *Test cases for optee-test*).
+  And it will be include *pkcs11* of optee-test.
+  The checkbox config variable "OPTEE_CASES" allows you to give a path of *optee-test.json* if needed. Otherwise, it will use the default JSON file in the provier.
+  Please make sure the file can be accessed by checkbox.
+  e.g. OPTEE_CASES=/home/user/optee-test.json
+
 ## Test coverage
   We have covered the default tests of optee-test, which include: 
   - Benchmark

--- a/checkbox-provider-ce-oem/units/optee/jobs.pxu
+++ b/checkbox-provider-ce-oem/units/optee/jobs.pxu
@@ -25,16 +25,22 @@ _summary: Check if xtest is in the gedget snap.
 plugin: shell
 user: root
 estimated_duration: 20.0
+environ: OPTEE_TOOL
 command: 
-    gadget=$(snap list | awk '$NF == "gadget" {print $1}')
-    xtest=$(snap info "$gadget"|grep xtest)
-    if [[ "$xtest" ]]; then
-        echo -e "\nInfo: Gadget snap support xtest command!"
-        echo -e "$xtest"
-        exit 0
+    if [[ -z "$OPTEE_TOOL" ]]; then
+        gadget=$(snap list | awk '$NF == "gadget" {print $1}')
+        xtest=$(snap info "$gadget"|grep xtest)
+        if [[ "$xtest" ]]; then
+            echo -e "\nInfo: Gadget snap support xtest command!"
+            echo -e "$xtest"
+            exit 0
+        else
+            echo -e "\nError: Gadget snap not support xtest command!"
+            echo -e "\nError: Please identify the tool name if needed!"
+            exit 1
+        fi
     else
-        echo -e "\nError: Gadget snap not support xtest command!"
-        exit 1
+        echo -e "\nInfo: Using $OPTEE_TOOL to excute OP-TEE test"
     fi
 depends: ce-oem-optee/device-node
 
@@ -45,17 +51,26 @@ plugin: shell
 user: root
 estimated_duration: 20.0
 depends: ce-oem-optee/xtest-check
-command: 
-    gadget=$(snap list | awk '$NF == "gadget" {print $1}')
-    # TA will be copied into this path once interface tee-tas connected.
-    # optee-test snap need to be installed in devmode
-    ta_path="/snap/$gadget/current/lib/optee_armtz/"
+environ: OPTEE_TOOL
+command:
+    tool=""
+    ta_path=""
+    if [[ -n "$OPTEE_TOOL" ]]; then
+        tool="$OPTEE_TOOL"
+        ta_path="/lib/optee_armtz/"
+    else
+        gadget=$(snap list | awk '$NF == "gadget" {print $1}')
+        # TA will be copied into this path once interface tee-tas connected.
+        # optee-test snap need to be installed in devmode
+        tool="$gadget.xtest"
+        ta_path="/snap/$gadget/current/lib/optee_armtz/"
+    fi
     if [[ -z "$(find "$ta_path" -mindepth 1 -type f -o -type d)" ]]; then
         echo -e "\nError: Not able to find TA!"
         exit 1
     else
         echo -e '\nAttempting to install TA ...'
-        if ! "$gadget.xtest" --install-ta "$ta_path"; then
+        if ! "$tool" --install-ta "$ta_path"; then
             echo -e '\nError: TA installed FAIL!'
             exit 1
         else
@@ -67,14 +82,30 @@ id: ce-oem-optee-test-list
 estimated_duration: 1
 plugin: resource
 user: root
-command: parse_optee_test.py "$PLAINBOX_PROVIDER_DATA/optee-test.json"
+environ: OPTEE_CASES
+command:
+    filepath=""
+    if [[ -n "$OPTEE_CASES" ]]; then
+        filepath="$OPTEE_CASES"
+    else
+        filepath="$PLAINBOX_PROVIDER_DATA/optee-test.json"
+    fi
+    parse_optee_test.py "$filepath"
 _summary: Collect the test cases support by OP-TEE test(xtest) 
 
 id: ce-oem-optee-test-list-pkcs11
 estimated_duration: 1
 plugin: resource
 user: root
-command: parse_optee_test.py "$PLAINBOX_PROVIDER_DATA/optee-test.json" -p
+environ: OPTEE_CASES
+command: 
+    filepath=""
+    if [[ -n "$OPTEE_CASES" ]]; then
+        filepath="$OPTEE_CASES"
+    else
+        filepath="$PLAINBOX_PROVIDER_DATA/optee-test.json"
+    fi
+    parse_optee_test.py "$filepath" -p
 _summary: Collect the test cases related with PKCS11 support by OP-TEE test(xtest) 
 
 unit: template
@@ -90,9 +121,16 @@ category_id: optee
 estimated_duration: 30
 flags: also-after-suspend
 depends: ce-oem-optee/ta-install
-command: 
-    gadget=$(snap list | awk '$NF == "gadget" {print $1}')
-    "$gadget.xtest" -t {{ suite }} {{ test_id }}
+environ: OPTEE_TOOL
+command:
+    tool=""
+    if [[ -n "$OPTEE_TOOL" ]]; then
+        tool="$OPTEE_TOOL"
+    else
+        gadget=$(snap list | awk '$NF == "gadget" {print $1}')
+        tool="$gadget.xtest"
+    fi
+    "$tool" -t {{ suite }} {{ test_id }}
 
 unit: template
 template-resource: ce-oem-optee-test-list-pkcs11
@@ -108,5 +146,11 @@ estimated_duration: 30
 depends: ce-oem-optee/xtest-check
 flags: also-after-suspend
 command: 
-    gadget=$(snap list | awk '$NF == "gadget" {print $1}')
-    "$gadget.xtest" -t {{ suite }} {{ test_id }}
+    tool=""
+    if [[ -n "$OPTEE_TOOL" ]]; then
+        tool="$OPTEE_TOOL"
+    else
+        gadget=$(snap list | awk '$NF == "gadget" {print $1}')
+        tool="$gadget.xtest"
+    fi
+    "$tool" -t {{ suite }} {{ test_id }}


### PR DESCRIPTION
Add: support outsourcing optee-test

Add: config var explanation in README.md

sideload result for TI-EVK(out sourcing optee-test): 
https://certification.canonical.com/hardware/202308-31996/submission/331513/

sideload result for high-pdk(build-in optee-test in gadget):
https://certification.canonical.com/hardware/202304-31534/submission/331171/