### PR TITLE
Fix: include python3-systemd in tox.ini

### DIFF
--- a/checkbox-provider-ce-oem/tox.ini
+++ b/checkbox-provider-ce-oem/tox.ini
@@ -5,6 +5,8 @@ skipsdist=True
 
 [testenv]
 allowlist_externals = rm
+debian_deps =
+    python3-systemd 
 commands =
     pip -q install ../../checkbox-ng
     # Required because this provider depends on checkbox-support parsers & scripts


### PR DESCRIPTION
include the python3-systemd package in tox.ini

I have implemented a python scripts with systemd module, but the python3-systemd is not built-in in the test environment.

the tox.ini file has been validated on my personal repo
https://github.com/stanley31huang/checkbox-provider-ce-oem/actions/runs/6233031599