### PR TITLE
Revamp otg_ports resource job should not fail

### DIFF
--- a/checkbox-provider-ce-oem/units/otg/jobs.pxu
+++ b/checkbox-provider-ce-oem/units/otg/jobs.pxu
@@ -13,7 +13,7 @@ command:
     if [ "$OTG" ]; then
         multiple-otg.sh -c "$OTG"
     else
-        echo "OTG config variable not found:"
+        echo "OTG config variable: not found"
     fi
 
 unit: template

--- a/checkbox-provider-ce-oem/units/otg/jobs.pxu
+++ b/checkbox-provider-ce-oem/units/otg/jobs.pxu
@@ -10,7 +10,11 @@ environ: OTG
 flags: preserve-locale
 user: root
 command:
-    multiple-otg.sh -c "$OTG"
+    if [ "$OTG" ]; then
+        multiple-otg.sh -c "$OTG"
+    else
+        echo "OTG config variable not found:"
+    fi
 
 unit: template
 template-resource: otg_ports


### PR DESCRIPTION
Add a `if condition` to handle when the OTG config variable is not set. We expect the resource job not to fail even if the OTG feature is not supported.

Adding a `:` after the sentence because Checkbox will check the format for the resource job which usually needs to be `key:value`. If `:` is not added, there will be a warning
```sh
invalid RFC822 data: Unexpected non-empty line: 'OTG config variable not found' (line 1)
```

Sideload result:
```
iotuc@ubuntu:~$ checkbox-shiner.checkbox-cli run .*::otg_ports
Using sideloaded provider: checkbox-provider-ce-oem, version 0.1 from /var/tmp/checkbox-providers/checkbox-provider-ce-oem
===========================[ Running Selected Jobs ]============================
==============[ Running job 1 / 1. Estimated time left: 0:00:01 ]===============
---------------------[ Gather list of USB ports and UDC. ]----------------------
ID: com.canonical.qa.ceoem::otg_ports
Category: com.canonical.plainbox::uncategorised
... 8< -------------------------------------------------------------------------
OTG config variable not found:------------------------------------------------------------------------- >8 ---
Outcome: job passed
Finalizing session that hasn't been submitted anywhere: checkbox-run-2023-09-26T07.15.50
==================================[ Results ]===================================
 ☑ : Gather list of USB ports and UDC.
 ```
