### PR TITLE
Fix: errors when mtd count is 0

### DIFF
--- a/checkbox-provider-ce-oem/bin/mtd.sh
+++ b/checkbox-provider-ce-oem/bin/mtd.sh
@@ -11,6 +11,7 @@ listAllMtd() {
 }
 
 countMtd() {
+    # shellcheck disable=SC2126
     count=$( listAllMtd | grep "MTD_NAME" | wc -l )
     if [ "${1}" == "$count" ]; then
         echo "The number of MTD is correct!"

--- a/checkbox-provider-ce-oem/bin/mtd.sh
+++ b/checkbox-provider-ce-oem/bin/mtd.sh
@@ -11,7 +11,7 @@ listAllMtd() {
 }
 
 countMtd() {
-    count=$( listAllMtd | grep -c "MTD_NAME")
+    count=$( listAllMtd | grep "MTD_NAME" | wc -l )
     if [ "${1}" == "$count" ]; then
         echo "The number of MTD is correct!"
     else


### PR DESCRIPTION
The original script uses `grep -c` to count the numbers of mtds. The return code will be 1 `grep` failed (mtd not supported). With `set -e`, the script will break instantly which makes the `countMtd()` function not able to print anything and get the wrong result.

Fix the `grep -c` back to `wc -l` that was used in Shiner project. It will return 0 even if mtd is not found, which can make the test script and job work properly.

Test results on device not supported mtd:
```
iotuc@ubuntu:~$ sudo ./mtd.sh count 0
The number of MTD is correct!
```

Reference for shellcheck 2126
https://www.shellcheck.net/wiki/SC2126