### PR TITLE
Make ce-oem-info jobs be attachment jobs

### DIFF
--- a/checkbox-provider-ce-oem/units/installation-time/jobs.pxu
+++ b/checkbox-provider-ce-oem/units/installation-time/jobs.pxu
@@ -1,11 +1,13 @@
 id: ce-oem-info/snapd_installation_time
-plugin: shell
+plugin: attachment
 category_id: com.canonical.plainbox::info
 _summary: Snapd installation time statistics via snap change log
 estimated_duration: 5
 imports: from com.canonical.certification import lsb
 requires: lsb.distributor_id == 'Ubuntu Core'
-command: installation_time.py snapd -a timing
+command:
+    installation_time.py snapd -a timing
+    exit 0  # Make attachment job always pass
 _description: 
     Fetch the time of snapd change log, include 
     "Initialize system state" and "Initialize device"
@@ -15,21 +17,25 @@ category_id: com.canonical.plainbox::info
 id: ce-oem-info/snapd_installation_log
 estimated_duration: 1.0
 depends: ce-oem-info/snapd_installation_time
-command: installation_time.py snapd -a dump
+command:
+    installation_time.py snapd -a dump
+    exit 0  # Make attachment job always pass
 _summary: Gather Snapd installation time log
 user: root
 _description:
     Attaches Snapd change log of "Initialize system state" and "Initialize device"
     log to the results.
 
-plugin: shell
+plugin: attachment
 category_id: com.canonical.plainbox::info
 id: ce-oem-info/cloud_init_time
 estimated_duration: 5
 _summary: Cloud init finished time statistics
 imports: from com.canonical.certification import lsb
 requires: lsb.distributor_id == 'Ubuntu Core'
-command: installation_time.py cloud-init -f cloud-init.log -a timing
+command:
+    installation_time.py cloud-init -f cloud-init.log -a timing
+    exit 0  # Make attachment job always pass
 user: root
 _description: 
     Fetch the time from Cloud-init.log
@@ -40,19 +46,23 @@ id: ce-oem-info/cloud_init_time_log
 estimated_duration: 1.0
 depends: ce-oem-info/cloud_init_time
 _summary: Gather cloud init log
-command: installation_time.py cloud-init -f cloud-init.log -a dump
+command:
+    installation_time.py cloud-init -f cloud-init.log -a dump
+    exit 0  # Make attachment job always pass
 user: root
 _description:
     Attaches cloud init log to the results.
 
-plugin: shell
+plugin: attachment
 category_id: com.canonical.plainbox::info
 id: ce-oem-info/install_timing
 estimated_duration: 5
 _summary: Snapd installion time(seed + install system) via install timing log
 imports: from com.canonical.certification import lsb
 requires: lsb.distributor_id == 'Ubuntu Core'
-command: installation_time.py gzip-log -f install-timings.txt.gz -a timing
+command:
+    installation_time.py gzip-log -f install-timings.txt.gz -a timing
+    exit 0  # Make attachment job always pass
 user: root
 _description: 
     Fetch the time from install-timing.txt.gz
@@ -63,19 +73,23 @@ id: ce-oem-info/install_timing_log
 estimated_duration: 1.0
 depends: ce-oem-info/install_timing
 _summary: Gather install timing log
-command: installation_time.py gzip-log -f install-timings.txt.gz -a dump
+command:
+    installation_time.py gzip-log -f install-timings.txt.gz -a dump
+    exit 0  # Make attachment job always pass
 user: root
 _description:
     Attaches install timing log to the results.
 
-plugin: shell
+plugin: attachment
 category_id: com.canonical.plainbox::info
 id: ce-oem-info/install_mode_time
 estimated_duration: 5
 _summary: Install mode time statistics via install log
 imports: from com.canonical.certification import lsb
 requires: lsb.distributor_id == 'Ubuntu Core'
-command: installation_time.py gzip-log -f install-mode.log.gz -a timing
+command:
+    installation_time.py gzip-log -f install-mode.log.gz -a timing
+    exit 0  # Make attachment job always pass
 user: root
 _description: 
     Fetch the time from install-mode.log.gz
@@ -86,7 +100,9 @@ id: ce-oem-info/install_mode_time_log
 estimated_duration: 1.0
 depends: ce-oem-info/install_mode_time
 _summary: Gather install mode log
-command: installation_time.py gzip-log -f install-mode.log.gz -a dump
+command:
+    installation_time.py gzip-log -f install-mode.log.gz -a dump
+    exit 0  # Make attachment job always pass
 user: root
 _description:
     Attaches install mode log to the results.


### PR DESCRIPTION
ce-oem-info jobs are aimed at collecting the system bootup information from snapd and cloud-init to help developers analyze bugs. Therefore, these jobs are more suitable to be attachment jobs and should not fail even if some information can not be found. For example, some systems may not have cloud-init. In these systems, the job cannot gather the information from cloud-init, but this should not be a failure.

Sideload result:
https://pastebin.canonical.com/p/rvPq7pPD7r/