### PR TITLE
Revamp caam_hwrng_test by looping w/ smaller size

### DIFF
--- a/checkbox-provider-ce-oem/units/crypto/accelerator.pxu
+++ b/checkbox-provider-ce-oem/units/crypto/accelerator.pxu
@@ -52,18 +52,20 @@ command:
     fi
     echo "CAAM Job ring interrupt before using Hardware RNG: $init_interrupt"
     echo "Starting DD of /dev/hwrng ..."
-    dd if=/dev/hwrng bs=1M count=10 > /dev/null
-    echo "Finished DD ..."
-    interrupt=$(awk '/\.jr/ {printf "%s ",$2;next;}' /proc/interrupts|sed 's/ //g')
-    echo "CAAM Job ring interrupt after using Hardware RNG: $interrupt"
-    if [ "$interrupt" -gt "$init_interrupt" ];
-    then
-        echo "PASS: CAAM job ring interrupts have increased."
-        exit 0
-    else
-        echo "FAIL: CAAM job ring interrupts didn't increase!"
-        exit 1
-    fi
+    for i in {1..20}
+    do
+        dd if=/dev/hwrng bs=512K count=1 > /dev/null
+        echo "Finished $i/20 times DD ..."
+        interrupt=$(awk '/\.jr/ {printf "%s ",$2;next;}' /proc/interrupts|sed 's/ //g')
+        echo "Current job ring interrupt: $interrupt"
+        if [ "$interrupt" -gt "$init_interrupt" ];
+        then
+            echo "PASS: CAAM job ring interrupts have increased."
+            exit 0
+        fi
+    done
+    echo "FAIL: CAAM job ring interrupts didn't increase!"
+    exit 1
 
 id: ce-oem-crypto/caam/algo_check
 _summary: Check CAAM algorithm is in the system /proc/crypto


### PR DESCRIPTION
Some of the project devices' caam_hwrng have buffer, so previously the dd size was increased to 10M to exceed the buffer size to make the interrupt increased. But it will make the device without buffer take a very long time (over 30 mins) to do the dd command.

Therefore, this commit separated the size to 512K and looped it 20 times. On the device without buffer it could do 512K and detect the increased interrupt to get the pass result, which is much faster. On the device with buttfer it could also exceed the buffer by dd 20 times and detect the increased interrupt to get the pass result.

Sideload result without manifest
https://pastebin.canonical.com/p/8QT5RxbQN9/
The first device has buffer, the second device doesn't have buffer.
