### PR TITLE
Add: new socketcan stress test

### DIFF
--- a/checkbox-provider-ce-oem/bin/socketcan_busoff_test.py
+++ b/checkbox-provider-ce-oem/bin/socketcan_busoff_test.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import sys
 import os
 import argparse

--- a/checkbox-provider-ce-oem/bin/socketcan_busoff_test.py
+++ b/checkbox-provider-ce-oem/bin/socketcan_busoff_test.py
@@ -62,7 +62,6 @@ def monitor_can_state(can_link, expected_states, timeout):
             break
         cur_time = datetime.now()
 
-
         if (cur_time - start_time).total_seconds() > timeout:
             logging.error("CAN current state is not match")
             break
@@ -113,8 +112,7 @@ def can_bus_off_test(can_dev, timeout):
             for _ in range(10):
                 can_socket.send(can_pkt, timeout=5)
 
-            if monitor_can_state(
-                can_link, [CANLinkState.BUS_OFF], timeout):
+            if monitor_can_state(can_link, [CANLinkState.BUS_OFF], timeout):
                 print("The state of {} interface is BUS-OFF".format(can_dev))
 
                 print("Remove short connector from {} intf".format(can_dev))

--- a/checkbox-provider-ce-oem/bin/socketcan_busoff_test.py
+++ b/checkbox-provider-ce-oem/bin/socketcan_busoff_test.py
@@ -141,8 +141,9 @@ def register_arguments():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description='SocketCAN BUS-OFF Tests')
     parser.add_argument(
-        "-d", "--dev",
-        required=True
+        "-d", "--device",
+        required=True,
+        help="CAN network interface"
     )
     parser.add_argument(
         "-t", "--timeout",

--- a/checkbox-provider-ce-oem/bin/socketcan_busoff_test.py
+++ b/checkbox-provider-ce-oem/bin/socketcan_busoff_test.py
@@ -1,0 +1,173 @@
+import sys
+import os
+import argparse
+import logging
+import time
+from datetime import datetime
+from socketcan_socket import CANSocket, CANLinkState, prepare_can_link
+
+
+def init_logger():
+    """
+    Set the logger to log DEBUG and INFO to stdout, and
+    WARNING, ERROR, CRITICAL to stderr.
+    """
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+    logger_format = "%(asctime)s %(levelname)-8s %(message)s"
+    date_format = "%Y-%m-%d %H:%M:%S"
+
+    # Log DEBUG and INFO to stdout, others to stderr
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setFormatter(logging.Formatter(logger_format, date_format))
+
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setFormatter(logging.Formatter(logger_format, date_format))
+
+    stdout_handler.setLevel(logging.DEBUG)
+    stderr_handler.setLevel(logging.WARNING)
+
+    # Add a filter to the stdout handler to limit log records to
+    # INFO level and below
+    stdout_handler.addFilter(lambda record: record.levelno <= logging.INFO)
+
+    root_logger.addHandler(stderr_handler)
+    root_logger.addHandler(stdout_handler)
+
+    return root_logger
+
+
+def monitor_can_state(can_link, expected_states, timeout):
+    """
+    Monitor CAN current state until it becomes expected state
+
+    Args:
+        can_dev (str):          CAN device name
+        expected_state (list):  a list of CAN states
+        timeout (int):          timeout
+    """
+    result = False
+    start_time = datetime.now()
+
+    expected_states = [state.value for state in expected_states]
+    logging.info("Expected CAN state: %s", expected_states)
+
+    while True:
+        can_link.get_link_info()
+        can_state = can_link.state
+        logging.info("Current CAN state: %s", can_state)
+
+        if can_state in expected_states:
+            result = True
+            break
+        cur_time = datetime.now()
+
+
+        if (cur_time - start_time).total_seconds() > timeout:
+            logging.error("CAN current state is not match")
+            break
+
+        time.sleep(1)
+
+    return result
+
+
+def can_bus_off_test(can_dev, timeout):
+    """
+    CAN BUS-OFF test
+
+    Args:
+        can_dev (str):  CAN device name
+        timeout (int):  timeout
+
+    Raises:
+        SystemExit:     Test failed with description
+    """
+
+    logging.info("Initial CAN Link object with %s", can_dev)
+    with prepare_can_link(can_dev) as can_link:
+        # the state must not be BUS-OFF and STOPPED before testing
+        logging.info("Check current state for %s interface", can_dev)
+        expected_state = monitor_can_state(
+            can_link,
+            [
+                CANLinkState.ERROR_ACTIVE,
+                CANLinkState.ERROR_PASSIVE,
+                CANLinkState.ERROR_WARNING
+            ],
+            timeout
+        )
+
+        if expected_state:
+            print("Short CAN_H and CAN_L for {} interface".format(can_dev))
+            print("And press Enter..")
+            input()
+
+            can_socket = CANSocket(can_dev, False)
+            can_pkt = can_socket.struct_packet(
+                222,
+                os.urandom(8),
+                0,
+                fd_frame=False
+            )
+            for _ in range(10):
+                can_socket.send(can_pkt, timeout=5)
+
+            if monitor_can_state(
+                can_link, [CANLinkState.BUS_OFF], timeout):
+                print("The state of {} interface is BUS-OFF".format(can_dev))
+
+                print("Remove short connector from {} intf".format(can_dev))
+                print("And press Enter..")
+                input()
+                if monitor_can_state(
+                    can_link,
+                    [
+                        CANLinkState.ERROR_ACTIVE,
+                        CANLinkState.ERROR_PASSIVE,
+                        CANLinkState.ERROR_WARNING
+                    ],
+                    timeout
+                ):
+                    logging.info("CAN state is recovered from BUS-OFF state")
+            else:
+                raise SystemExit("the CAN state is not BUS-OFF")
+        else:
+            raise SystemExit("Initial CAN current state is not expected.")
+
+
+def register_arguments():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description='SocketCAN BUS-OFF Tests')
+    parser.add_argument(
+        "-d", "--dev",
+        required=True
+    )
+    parser.add_argument(
+        "-t", "--timeout",
+        type=int,
+        default=60
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Turn on debug level output for extra info during test run.",
+    )
+
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = register_arguments()
+    print(args)
+
+    logger = init_logger()
+    if args.debug:
+        logger.setLevel(logging.DEBUG)
+    can_bus_off_test(args.dev, args.timeout)
+
+
+if __name__ == "__main__":
+    main()

--- a/checkbox-provider-ce-oem/bin/socketcan_socket.py
+++ b/checkbox-provider-ce-oem/bin/socketcan_socket.py
@@ -3,7 +3,6 @@ import struct
 import sys
 import json
 import subprocess
-import copy
 import logging
 import contextlib
 from enum import Enum

--- a/checkbox-provider-ce-oem/bin/socketcan_socket.py
+++ b/checkbox-provider-ce-oem/bin/socketcan_socket.py
@@ -1,0 +1,375 @@
+import socket
+import struct
+import sys
+import json
+import subprocess
+import copy
+import logging
+import contextlib
+from enum import Enum
+
+
+def init_logger():
+    """
+    Set the logger to log DEBUG and INFO to stdout, and
+    WARNING, ERROR, CRITICAL to stderr.
+    """
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+    logger_format = "%(asctime)s %(levelname)-8s %(message)s"
+    date_format = "%Y-%m-%d %H:%M:%S"
+
+    # Log DEBUG and INFO to stdout, others to stderr
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setFormatter(logging.Formatter(logger_format, date_format))
+
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setFormatter(logging.Formatter(logger_format, date_format))
+
+    stdout_handler.setLevel(logging.DEBUG)
+    stderr_handler.setLevel(logging.WARNING)
+
+    # Add a filter to the stdout handler to limit log records to
+    # INFO level and below
+    stdout_handler.addFilter(lambda record: record.levelno <= logging.INFO)
+
+    root_logger.addHandler(stderr_handler)
+    root_logger.addHandler(stdout_handler)
+
+    return root_logger
+
+
+class CANSocket():
+
+    # struct module format strings for CAN packets
+    # Normal format:
+    #   <   little-endian
+    #   I   unsigned int (4)    : CAN-ID + EFF/RTR/ERR Flags
+    #   B   unsigned char (1)   : Data length
+    #   3x  padding (3 * 1)     : -
+    #   8s  char array (8 * 1)  : Data
+    FORMAT = "<IB3x8s"
+    # Flexible Data (FD) rate format:
+    #   <    little-endian
+    #   I    unsigned int (4)    : CAN-ID + EFF/RTR/ERR Flags
+    #   B    unsigned char (1)   : Data length
+    #   B    unsigned char (1)   : FD Flags
+    #   2x   padding (2 * 1)     : -
+    #   64s  char array (64 * 1) : Data
+    FD_FORMAT = "<IBB2x64s"
+
+    CAN_MTU = struct.Struct(FORMAT).size
+    CANFD_MTU = struct.Struct(FD_FORMAT).size
+
+    # Socket options from <linux/can/raw.h>
+    CAN_RAW_FILTER = 1         # set 0 .. n can_filter(s)
+    CAN_RAW_ERR_FILTER = 2     # set filter for error frames
+    CAN_RAW_LOOPBACK = 3       # local loopback (default:on)
+    CAN_RAW_RECV_OWN_MSGS = 4  # receive my own msgs (default:off)
+    CAN_RAW_FD_FRAMES = 5      # allow CAN FD frames (default:off)
+    CAN_RAW_JOIN_FILTERS = 6   # all filters must match to trigger
+
+    def __init__(self, interface=None, fdmode=False, verbose=False):
+        self.sock = socket.socket(socket.PF_CAN,  # protocol family
+                                  socket.SOCK_RAW,
+                                  socket.CAN_RAW)
+        self._fdmode = fdmode
+        self._verbose = verbose
+        if interface is not None:
+            self._bind(interface)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self):
+        self.close()
+
+    def close(self):
+        self.sock.close()
+
+    def _bind(self, interface):
+        self.sock.bind((interface,))
+        if self._fdmode:  # default is off
+            self.sock.setsockopt(
+                socket.SOL_CAN_RAW, self.CAN_RAW_FD_FRAMES, 1)
+
+    def struct_packet(
+            self, can_id, data, id_flag=0, fd_flag=0, fd_frame=False):
+        """
+        Generate CAN frame binary data
+
+        Args:
+            can_id (int):   CAN ID
+            data (byte):    CAN data packet
+            id_flag (int):  CAN ID flag
+            fd_flag (int):  additional FD flag
+            fd_frame (bol): FD frame data
+
+        Raises:
+            SystemExit: if any error occurs during receiving CAN frame
+        """
+        can_id = can_id | id_flag
+        if fd_frame:
+            can_packet = struct.pack(
+                self.FD_FORMAT,
+                can_id,
+                len(data),
+                fd_flag,
+                data
+            )
+        else:
+            can_packet = struct.pack(
+                self.FORMAT,
+                can_id,
+                len(data),
+                data
+            )
+
+        return can_packet
+
+    def destruct_packet(self, can_packet):
+        nbytes = len(can_packet)
+        logging.debug("Destruct CAN packet..")
+        if nbytes == self.CANFD_MTU:
+            logging.debug("Got CAN FD frame..")
+            can_id, length, fd_flags, data = struct.unpack(
+                    self.FD_FORMAT, can_packet)
+        elif nbytes == self.CAN_MTU:
+            logging.debug("Got Classical CAN frame..")
+            can_id, length, data = struct.unpack(
+                    self.FORMAT, can_packet)
+        else:
+            logging.error("Got an unexpected data with length %s", nbytes)
+            return (None, None)
+
+        can_id &= socket.CAN_EFF_MASK
+        if can_id and data[:length] and self._verbose:
+            logging.debug('CAN packet data')
+            logging.debug('  ID  : %s', '{:x}'.format(can_id))
+            logging.debug('  Data: %s', data[:length].hex())
+
+        return (can_id, data[:length])
+
+    def send(self, can_packet, timeout=None):
+        """
+        Send CAN frame data through CANSocket
+
+        Args:
+            can_packet (): CAN data packet
+            timeout:
+
+        Raises:
+            SystemExit: if any error occurs during receiving CAN frame
+        """
+        try:
+            if timeout:
+                self.sock.settimeout(timeout)
+            self.sock.send(can_packet)
+            self.sock.settimeout(None)
+        except OSError as e:
+            logging.error(e)
+            if e.errno == 90:
+                raise SystemExit(
+                    'ERROR: interface does not support FD Mode')
+            else:
+                raise SystemExit('ERROR: OSError on attempt to send')
+
+    def recv(self, timeout=None):
+        """
+        Receive data from CANSocket
+
+        Raises:
+            SystemExit: if any error occurs during receiving CAN frame
+        """
+        data_struct = self.CANFD_MTU if self._fdmode else self.CAN_MTU
+        try:
+            if timeout:
+                self.sock.settimeout(timeout)
+            can_pkt = self.sock.recv(data_struct)
+            self.sock.settimeout(None)
+            return can_pkt
+        except TimeoutError:
+            logging.error("Failed to receive within %ss", 5)
+            return None
+        except OSError as e:
+            logging.error(e)
+            if e.errno == 90:
+                raise SystemExit(
+                    'ERROR: interface does not support FD Mode')
+            else:
+                raise SystemExit('ERROR: OSError on attempt to receive')
+
+
+class CANLinkState(Enum):
+
+    ERROR_ACTIVE = "ERROR-ACTIVE"
+    ERROR_WARNING = "ERROR-WARNING"
+    ERROR_PASSIVE = "ERROR-PASSIVE"
+    BUS_OFF = "BUS-OFF"
+    STOPPED = "STOPPED"
+
+
+class CANLinkInfo():
+    """
+    CAN Link Information
+    """
+    def __init__(self, dev):
+        self._can_dev = dev
+        self._can_raw_data = None
+        self._raw_data = None
+        self.get_link_info()
+
+    def get_link_info(self):
+
+        ret = subprocess.run(
+            "ip -d -j link show {}".format(self._can_dev),
+            shell=True,
+            capture_output=True
+        )
+        try:
+            json_data = json.loads(ret.stdout.decode("utf-8").strip("\n"))
+            self._raw_data = json_data[0]
+            if json_data[0]["linkinfo"]["info_kind"] == "can":
+                self._can_raw_data = json_data[0]["linkinfo"]["info_data"]
+        except Exception as e:
+            logging.error("Unexpected error: %s", e)
+
+    @property
+    def bittiming(self):
+        if self._can_raw_data:
+            return self._can_raw_data.get("bittiming", {})
+
+    @property
+    def data_bittiming(self):
+        if self._can_raw_data:
+            return self._can_raw_data.get("data_bittiming", {})
+
+    @property
+    def restart_ms(self):
+        if self._can_raw_data:
+            return self._can_raw_data["restart_ms"]
+
+    @property
+    def state(self):
+        if self._can_raw_data:
+            return self._can_raw_data["state"]
+
+    @property
+    def operate_state(self):
+        return self._raw_data["operstate"]
+
+    @property
+    def mtu(self):
+        return self._raw_data["mtu"]
+
+    def configure(self, bittiming, data_bittiming={}, restart_ms=0, fd=False):
+        """
+        Configure the CAN attribute
+
+        Args:
+            bittiming (dict): bitrate attributes
+            data_bittiming (dict, optional):
+                data bitrate attributes. Defaults to {}.
+            restart_ms (int, optional):
+                restart timeout. Defaults to 0.
+            fd (bool, optional):
+                CAN FD mode. Defaults to False.
+        """
+        supported_attributes = ["bitrate", "sample_point"]
+        self.get_link_info()
+
+        cmd_str = ""
+        for key, value in bittiming.items():
+            if key in supported_attributes:
+                cmd_str = "{} {} {}".format(cmd_str,
+                                            key.replace("_", "-"),
+                                            value)
+
+        for key, value in data_bittiming.items():
+            if key in supported_attributes:
+                cmd_str = "{} d{} {}".format(cmd_str,
+                                             key.replace("_", "-"),
+                                             value)
+        mtu = 16
+        if fd:
+            mtu = 72
+            cmd_str = "{} fd on".format(cmd_str)
+
+        if restart_ms:
+            cmd_str = "{} restart-ms {}".format(cmd_str, restart_ms)
+
+        if cmd_str:
+            cmd_str = "ip link set {} mtu {} type can {}".format(
+                self._can_dev, mtu, cmd_str
+            )
+            logging.debug(
+                "configure CAN %s device - '%s'", self._can_dev, cmd_str
+            )
+            subprocess.run(cmd_str, shell=True)
+        else:
+            logging.debug("CAN attribute has no difference")
+
+    def enable_link(self):
+        """
+        Enable CAN Link
+        """
+        logging.debug("enable CAN %s device", self._can_dev)
+        subprocess.run("ip link set {} up".format(self._can_dev), shell=True)
+
+    def disable_link(self):
+        """
+        Disable CAN Link
+        """
+        logging.debug("disable CAN %s device", self._can_dev)
+        subprocess.run(
+            "ip link set {} down".format(self._can_dev), shell=True)
+
+
+@contextlib.contextmanager
+def prepare_can_link(can_dev, fd_mode=False):
+    try:
+        can_link = CANLinkInfo(can_dev)
+        original_bitrate = can_link.bittiming
+        original_dbitrate = can_link.data_bittiming
+        original_restart_ms = can_link.restart_ms
+        original_op_state = can_link.operate_state
+        original_mtu = can_link.mtu
+
+        if can_link.operate_state == "UP":
+            can_link.disable_link()
+
+        if fd_mode:
+            can_link.configure(
+                bittiming={"bitrate": 1000000},
+                data_bittiming={"bitrate": 2000000},
+                restart_ms=30000,
+                fd=fd_mode
+            )
+        else:
+            can_link.configure(
+                bittiming={"bitrate": 1000000},
+                data_bittiming={},
+                restart_ms=30000
+            )
+
+        can_link.enable_link()
+        yield can_link
+
+    finally:
+        print("Restore {} configuration".format(can_dev))
+        can_link.disable_link()
+        if original_mtu == 72:
+            can_link.configure(
+                bittiming=original_bitrate,
+                data_bittiming=original_dbitrate,
+                restart_ms=original_restart_ms,
+                fd=fd_mode
+            )
+        else:
+            can_link.configure(
+                bittiming=original_bitrate,
+                restart_ms=original_restart_ms
+            )
+
+        if original_op_state == "UP":
+            can_link.enable_link()

--- a/checkbox-provider-ce-oem/bin/socketcan_socket.py
+++ b/checkbox-provider-ce-oem/bin/socketcan_socket.py
@@ -104,8 +104,8 @@ class CANSocket():
             fd_flag (int):  additional FD flag
             fd_frame (bol): FD frame data
 
-        Raises:
-            SystemExit: if any error occurs during receiving CAN frame
+        Return:
+            can_packet(bytes): a bytes object of CAN packet
         """
         can_id = can_id | id_flag
         if fd_frame:
@@ -154,11 +154,11 @@ class CANSocket():
         Send CAN frame data through CANSocket
 
         Args:
-            can_packet (): CAN data packet
-            timeout:
+            can_packet: CAN data packet
+            timeout:    timeout for sending packet
 
         Raises:
-            SystemExit: if any error occurs during receiving CAN frame
+            SystemExit: if any error occurs during sending CAN frame
         """
         try:
             if timeout:
@@ -177,6 +177,9 @@ class CANSocket():
         """
         Receive data from CANSocket
 
+        Args:
+            timeout:    timeout for sending packet
+
         Raises:
             SystemExit: if any error occurs during receiving CAN frame
         """
@@ -188,7 +191,7 @@ class CANSocket():
             self.sock.settimeout(None)
             return can_pkt
         except TimeoutError:
-            logging.error("Failed to receive within %ss", 5)
+            logging.error("Failed to receive within %ss", timeout)
             return None
         except OSError as e:
             logging.error(e)
@@ -200,12 +203,18 @@ class CANSocket():
 
 
 class CANLinkState(Enum):
+    """CAN Link State
 
+    Reference link:
+    https://github.com/torvalds/linux/blob/master/include/uapi/linux/can/netlink.h#L69
+    """
     ERROR_ACTIVE = "ERROR-ACTIVE"
     ERROR_WARNING = "ERROR-WARNING"
     ERROR_PASSIVE = "ERROR-PASSIVE"
     BUS_OFF = "BUS-OFF"
     STOPPED = "STOPPED"
+    SLEEPING = "SLEEPING"
+    MAX = "MAX"
 
 
 class CANLinkInfo():

--- a/checkbox-provider-ce-oem/bin/socketcan_test.py
+++ b/checkbox-provider-ce-oem/bin/socketcan_test.py
@@ -1,0 +1,510 @@
+import argparse
+import ctypes
+import os
+import socket
+import struct
+import sys
+import time
+import datetime
+import logging
+
+
+def init_logger():
+    """
+    Set the logger to log DEBUG and INFO to stdout, and
+    WARNING, ERROR, CRITICAL to stderr.
+    """
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+    logger_format = "%(asctime)s %(levelname)-8s %(message)s"
+    date_format = "%Y-%m-%d %H:%M:%S"
+
+    # Log DEBUG and INFO to stdout, others to stderr
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setFormatter(logging.Formatter(logger_format, date_format))
+
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setFormatter(logging.Formatter(logger_format, date_format))
+
+    stdout_handler.setLevel(logging.DEBUG)
+    stderr_handler.setLevel(logging.WARNING)
+
+    # Add a filter to the stdout handler to limit log records to
+    # INFO level and below
+    stdout_handler.addFilter(lambda record: record.levelno <= logging.INFO)
+
+    root_logger.addHandler(stderr_handler)
+    root_logger.addHandler(stdout_handler)
+
+    return root_logger
+
+
+class CANSocket():
+
+    # struct module format strings for CAN packets
+    # Normal format:
+    #   <   little-endian
+    #   I   unsigned int (4)    : CAN-ID + EFF/RTR/ERR Flags
+    #   B   unsigned char (1)   : Data length
+    #   3x  padding (3 * 1)     : -
+    #   8s  char array (8 * 1)  : Data
+    FORMAT = "<IB3x8s"
+    # Flexible Data (FD) rate format:
+    #   <    little-endian
+    #   I    unsigned int (4)    : CAN-ID + EFF/RTR/ERR Flags
+    #   B    unsigned char (1)   : Data length
+    #   B    unsigned char (1)   : FD Flags
+    #   2x   padding (2 * 1)     : -
+    #   64s  char array (64 * 1) : Data
+    FD_FORMAT = "<IBB2x64s"
+
+    CAN_MTU = struct.Struct(FORMAT).size
+    CANFD_MTU = struct.Struct(FD_FORMAT).size
+
+    # Socket options from <linux/can/raw.h>
+    CAN_RAW_FILTER = 1         # set 0 .. n can_filter(s)
+    CAN_RAW_ERR_FILTER = 2     # set filter for error frames
+    CAN_RAW_LOOPBACK = 3       # local loopback (default:on)
+    CAN_RAW_RECV_OWN_MSGS = 4  # receive my own msgs (default:off)
+    CAN_RAW_FD_FRAMES = 5      # allow CAN FD frames (default:off)
+    CAN_RAW_JOIN_FILTERS = 6   # all filters must match to trigger
+
+    def __init__(self, interface=None, fdmode=False, verbose=False):
+        self.sock = socket.socket(socket.PF_CAN,  # protocol family
+                                  socket.SOCK_RAW,
+                                  socket.CAN_RAW)
+        self._fdmode = fdmode
+        self._verbose = verbose
+        if interface is not None:
+            self._bind(interface)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self):
+        self.close()
+
+    def close(self):
+        self.sock.close()
+
+    def _bind(self, interface):
+        self.sock.bind((interface,))
+        if self._fdmode:  # default is off
+            self.sock.setsockopt(
+                socket.SOL_CAN_RAW, self.CAN_RAW_FD_FRAMES, 1)
+
+    def struct_packet(self, can_id, data, id_flag=0, fd_flag=0):
+        """
+        Generate CAN frame binary data
+
+        Args:
+            can_id (int):   CAN ID
+            data (byte):    CAN data packet
+            id_flag:
+            fd_flag (int):  additional FD flag
+
+        can_id (int):       CAN ID
+        data (byte):        Random data with byte format
+        eff_flag (int):     CAN ID Flag. 0 means SFF, 1 means EFF
+
+        Raises:
+            SystemExit: if any error occurs during receiving CAN frame
+        """
+        can_id = can_id | id_flag
+        if self._fdmode:
+            can_packet = struct.pack(
+                self.FD_FORMAT,
+                can_id,
+                len(data),
+                fd_flag,
+                data
+            )
+        else:
+            can_packet = struct.pack(
+                self.FORMAT,
+                can_id,
+                len(data),
+                data
+            )
+
+        return can_packet
+
+    def destruct_packet(self, can_packet):
+        nbytes = len(can_packet)
+        logging.debug("Destruct CAN packet..")
+        if nbytes == self.CANFD_MTU:
+            logging.debug("Got CAN FD frame..")
+            can_id, length, fd_flags, data = struct.unpack(
+                    self.FD_FORMAT, can_packet)
+        elif nbytes == self.CAN_MTU:
+            logging.debug("Got Classical CAN frame..")
+            can_id, length, data = struct.unpack(
+                    self.FORMAT, can_packet)
+        else:
+            logging.error("Got an unexpected data with length %s", nbytes)
+            return (None, None)
+
+        can_id &= socket.CAN_EFF_MASK
+        if can_id and data[:length] and self._verbose:
+            logging.debug('CAN packet data')
+            logging.debug('  ID  : %s', '{:x}'.format(can_id))
+            logging.debug('  Data: %s', data[:length].hex())
+
+        return (can_id, data[:length])
+
+    def send(self, can_packet, timeout=None):
+        """
+        Send CAN frame data through CANSocket
+
+        Args:
+            can_packet (): CAN data packet
+            timeout:
+
+        Raises:
+            SystemExit: if any error occurs during receiving CAN frame
+        """
+        try:
+            if timeout:
+                self.sock.settimeout(timeout)
+            self.sock.send(can_packet)
+            self.sock.settimeout(None)
+        except OSError as e:
+            logging.error(e)
+            if e.errno == 90:
+                raise SystemExit(
+                    'ERROR: interface does not support FD Mode')
+            else:
+                raise SystemExit('ERROR: OSError on attempt to send')
+
+    def recv(self, timeout=None):
+        """
+        Receive data from CANSocket
+
+        Raises:
+            SystemExit: if any error occurs during receiving CAN frame
+        """
+        data_struct = self.CANFD_MTU if self._fdmode else self.CAN_MTU
+        try:
+            if timeout:
+                self.sock.settimeout(timeout)
+            can_pkt = self.sock.recv(data_struct)
+            self.sock.settimeout(None)
+            return can_pkt
+        except TimeoutError:
+            logging.error("Failed to receive within %ss", 5)
+            return None
+        except OSError as e:
+            logging.error(e)
+            if e.errno == 90:
+                raise SystemExit(
+                    'ERROR: interface does not support FD Mode')
+            else:
+                raise SystemExit('ERROR: OSError on attempt to receive')
+
+
+def send_string_back(sender, can_id, data, eff_flag):
+    """
+    Start CAN Echo server
+
+    Args:
+        sender (obj):       CANSocket object
+        can_id (int):       CAN ID
+        data (byte):        Random data with byte format
+        eff_flag (int):     CAN ID Flag. 0 means SFF, 1 means EFF
+
+    Raises:
+        SystemExit: if any error occurs during send CAN frame
+    """
+    logging.info('Echo data back...')
+    try:
+        can_pkt = sender.struct_packet(can_id, data, eff_flag)
+        sender.send(can_pkt)
+    except OSError as e:
+        logging.error(e)
+        if e.errno == 90:
+            raise SystemExit(
+                'ERROR: interface does not support FD Mode')
+        else:
+            raise SystemExit('ERROR: OSError on attempt to send')
+
+
+def start_echo_server(interface, fd_mode, delay=0.001):
+    """
+    Start CAN Echo server
+
+    Args:
+        interface (str):    network interface of SocketCAN, e.g. can0
+        fd_mode (bool):     FD mode enable
+        delay (float):      The time delay before echo CAN frame
+    """
+
+    logging.info('Start SocketCAN echo server')
+    can_socket = CANSocket(interface, fd_mode)
+    while True:
+        recv_pkt = can_socket.recv()
+        recv_id, recv_data = can_socket.destruct_packet(recv_pkt)
+        logging.info('Received packet')
+        logging.info('  ID  : %s', '{:x}'.format(recv_id))
+        logging.info('  Data: %s', recv_data.hex())
+        time.sleep(delay)
+        if recv_id > 2047:
+            id_flags = socket.CAN_EFF_FLAG
+        else:
+            id_flags = 0
+
+        client_fd_mode = True if len(recv_data) == 64 else False
+        if client_fd_mode is False and client_fd_mode != fd_mode:
+            # Switch to FD frame to 0 to support classic CAN
+            can_socket.sock.setsockopt(
+                socket.SOL_CAN_RAW, can_socket.CAN_RAW_FD_FRAMES, 0
+            )
+            send_string_back(
+                can_socket, recv_id, recv_data, id_flags
+            )
+            # Switch to FD frame to 1 to support FD CAN
+            can_socket.sock.setsockopt(
+                socket.SOL_CAN_RAW, can_socket.CAN_RAW_FD_FRAMES, 1
+            )
+        else:
+            send_string_back(
+                can_socket, recv_id, recv_data, id_flags
+            )
+
+
+def _random_can_data(can_id, eff_flag, data_size):
+    """
+    Generate CAN frame data with specific data length
+
+    Args:
+        can_id (str):       CAN ID
+        eff_flag (bool):    EFF CAN ID Enable
+        data_size (int):    The data length
+
+    Return:
+        can_id_int (int):   CAN ID
+        data_bytes (byte):  Random data with byte format
+        id_flag (int):      CAN ID Flag. 0 means SFF, 1 means EFF
+    """
+    # ID conversion and size check
+    logging.debug('Using source ID: %s', can_id)
+    can_id_int = int(can_id, 16)
+    if can_id_int > 2047 and eff_flag is False:
+        raise SystemExit('ERROR: CAN ID to high for SFF')
+
+    id_flag = 0
+    if eff_flag:
+        logging.debug('Setting EFF CAN ID flag')
+        id_flag = ctypes.c_ulong(socket.CAN_EFF_FLAG).value
+
+    data_bytes = os.urandom(data_size)
+
+    return can_id_int, data_bytes, id_flag
+
+
+def echo_test(interface, can_id, eff_flag, fd_mode):
+    """
+    Perform the echo test through SocketCAN bus
+
+    Args:
+        interface (str): network interface of SocketCAN, e.g. can0
+        can_id (str):       CAN ID
+        eff_flag (bool):    EFF CAN ID Enable
+        fd_mode (bool):     FD mode enable
+
+    Raises:
+        SystemExit: if received CAN frame data is not correct
+    """
+    data_size = 64 if fd_mode else 8
+    can_id_i, data_b, id_flags = _random_can_data(
+                        can_id, eff_flag, data_size)
+    logging.info('Sending data: %s', data_b.hex())
+
+    recv_id = recv_data = None
+
+    can_socket = CANSocket(interface, fd_mode)
+    can_pkt = can_socket.struct_packet(can_id_i, data_b, id_flags, fd_mode)
+    can_socket.send(can_pkt, timeout=5)
+
+    can_recv_pkt = can_socket.recv(5)
+    recv_id, recv_data = can_socket.destruct_packet(can_recv_pkt)
+
+    if recv_id != can_id_i or recv_data != data_b:
+        raise SystemExit('ERROR: ID/Data received does not match sent')
+    else:
+        logging.info('\nPASSED')
+
+
+def stress_echo_test(interface, can_id, eff_flag, fd_mode, count=30):
+    """
+    Perform the echo stress test through SocketCAN bus
+
+    Args:
+        interface (str): network interface of SocketCAN, e.g. can0
+        can_id (str):       CAN ID
+        eff_flag (bool):    EFF CAN ID Enable
+        fd_mode (bool):     FD mode enable
+        count (int):        Stress test cycle
+
+    Raises:
+        SystemExit: if received CAN frames is not expected
+    """
+    # Due to the timestamp data is 8 bytes
+    # So we need to generate extra random data (56 bytes)
+    data_size = 56 if fd_mode else 0
+
+    can_id_i, prefix_data, id_flags = _random_can_data(
+                        can_id, eff_flag, data_size)
+
+    can_socket = CANSocket(interface, fd_mode)
+
+    logging.info("Generate data for stress tests")
+    original_records = [
+        can_socket.struct_packet(
+            can_id_i,
+            b"".join([
+                prefix_data,
+                bytes.fromhex(
+                    str(int(datetime.datetime.now().timestamp()*1000000)))
+            ]),
+            id_flags,
+            fd_mode
+        ) for _ in range(count)
+    ]
+
+    time_format = "%Y-%m-%d %H:%M:%S"
+    recv_records = []
+
+    start_time = datetime.datetime.now()
+    logging.info(
+        "# Start stress echo string test at %s",
+        start_time.strftime(time_format)
+    )
+    for can_pkt in original_records:
+        can_socket.send(can_pkt, timeout=5)
+        recv_records.append(can_socket.recv(5))
+        if recv_records[-1] is None:
+            logging.error(
+                "Stop testing due to failed to receive packet"
+            )
+            logging.error(
+                "Received %d packets from CAN echo server",
+                len(recv_records)
+            )
+            raise SystemExit("CAN ECHO Stress test failed")
+
+    end_time = datetime.datetime.now()
+    logging.info("# End stress echo string test at {}".format(
+        end_time.strftime(time_format)
+    ))
+
+    elapsed_time = end_time - start_time
+    logging.info("received %s frames in %s", len(recv_records), elapsed_time)
+
+    if len(recv_records) == count:
+        logging.info("# Checking the data in received frames")
+        failed_count = 0
+        for index, data in enumerate(original_records):
+            # validate data field in CAN packet only
+            if can_socket.destruct_packet(recv_records[index]) != \
+               can_socket.destruct_packet(data):
+                failed_count += 1
+                logging.error("Received data in unexpected!")
+                logging.error("Received data: %s", recv_records[index])
+                logging.error("Expected data: %s", data)
+
+        if failed_count > 0:
+            logging.error("Found %s incorrect data frames", failed_count)
+            raise SystemExit("CAN ECHO Stress test failed")
+        else:
+            logging.info("CAN ECHO Stress test passed")
+
+    else:
+        logging.error(
+            "%s frames is received, but %s is expected",
+            len(recv_records),
+            count
+        )
+        raise SystemExit("CAN ECHO Stress test failed")
+
+
+def register_arguments():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description='SocketCAN Tests')
+    parser.add_argument(
+        "-d", "--dev",
+        required=True
+    )
+    parser.add_argument(
+        "-f", "--fd-mode",
+        action="store_true",
+        default=False
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Turn on debug level output for extra info during test run.",
+    )
+
+    subparsers = parser.add_subparsers(
+        dest="mode",
+        required=True
+    )
+    server_parser = subparsers.add_parser("server")
+    server_parser.add_argument(
+        "-t", "--time-delay",
+        type=float,
+        default=0.001
+    )
+
+    client_parser = subparsers.add_parser("client")
+    client_parser.add_argument(
+        "-x", "--execute-test",
+        type=str,
+        choices=["stress-echo", "echo"],
+        default="stress-echo"
+    )
+    client_parser.add_argument(
+        "-c", "--can-id",
+        type=str,
+        required=True
+    )
+    client_parser.add_argument(
+        "-e", "--eff-mode",
+        action="store_true",
+        default=False
+    )
+    client_parser.add_argument(
+        "-l", "--loop",
+        type=int,
+        default=30
+    )
+
+    args = parser.parse_args()
+    return args
+
+
+def main():
+
+    args = register_arguments()
+    print(args)
+
+    logger = init_logger()
+    if args.debug:
+        logger.setLevel(logging.DEBUG)
+
+    if args.mode == "server":
+        start_echo_server(args.dev, args.fd_mode, args.time_delay)
+    elif args.mode == "client":
+        if args.execute_test == "stress-echo":
+            stress_echo_test(
+                args.dev, args.can_id, args.eff_mode, args.fd_mode, args.loop
+            )
+        elif args.execute_test == "echo":
+            echo_test(
+                args.dev, args.can_id, args.eff_mode, args.fd_mode
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/checkbox-provider-ce-oem/units/socketcan/jobs.pxu
+++ b/checkbox-provider-ce-oem/units/socketcan/jobs.pxu
@@ -1,0 +1,55 @@
+unit: template
+template-resource: com.canonical.certification::device
+template-filter: device.category == 'SOCKETCAN'
+id: socketcan/stress_fd_remote_{interface}
+_summary: Send stress test through CAN device {interface} (Raw, Remote, FD)
+_description:
+    Test a CAN device by sending packets using a raw socket to a remote device.
+    As a prerequisite the remote device should have can-echo-server installed so
+    as to return the predicted packet.
+category_id: com.canonical.certification::socketcan
+plugin: shell
+user: root
+estimated_duration: 10m
+flags: also-after-suspend
+imports: from com.canonical.plainbox import manifest
+requires:
+    manifest.socket_can_echo_server_running == 'True'
+    socket_can_fd == 'True'
+command:
+    BASH_XTRACEFD=1
+    set -ex
+    ip link set {interface} down
+    # Following command is only supported configuration method when using the
+    # IXXAT driver from HMS
+    ip link set {interface} type can bitrate 1000000 dbitrate 2000000 fd on
+    ip link set {interface} up
+    socketcan_test.py -d {interface} -f client -x stress-echo -l 100000 -c 123
+
+unit: template
+template-resource: com.canonical.certification::device
+template-filter: device.category == 'SOCKETCAN'
+id: socketcan/stress_remote_{interface}
+_summary: Send stress test through CAN device {interface} (Raw, Remote)
+_description:
+    Test a CAN device by sending packets using a raw socket to a remote device.
+    As a prerequisite the remote device should have can-echo-server installed so
+    as to return the predicted packet.
+category_id: com.canonical.certification::socketcan
+plugin: shell
+user: root
+estimated_duration: 10m
+flags: also-after-suspend
+imports: from com.canonical.plainbox import manifest
+requires:
+    manifest.socket_can_echo_server_running == 'True'
+command:
+    BASH_XTRACEFD=1
+    set -ex
+    ip link set {interface} down
+    # Following command is only supported configuration method when using the
+    # IXXAT driver from HMS
+    ip link set {interface} type can bitrate 1000000
+    ip link set dev {interface} mtu 16
+    ip link set {interface} up
+    socketcan_test.py -d {interface} client -x stress-echo -l 100000 -c 123

--- a/checkbox-provider-ce-oem/units/socketcan/jobs.pxu
+++ b/checkbox-provider-ce-oem/units/socketcan/jobs.pxu
@@ -1,7 +1,7 @@
 unit: template
 template-resource: com.canonical.certification::device
 template-filter: device.category == 'SOCKETCAN'
-id: socketcan/stress_fd_remote_{interface}
+id: ce-oem-socketcan/stress_fd_remote_{interface}
 _summary: Send stress test through CAN device {interface} (Raw, Remote, FD)
 _description:
     Test a CAN device by sending packets using a raw socket to a remote device.
@@ -17,19 +17,12 @@ requires:
     manifest.socket_can_echo_server_running == 'True'
     socket_can_fd == 'True'
 command:
-    BASH_XTRACEFD=1
-    set -ex
-    ip link set {interface} down
-    # Following command is only supported configuration method when using the
-    # IXXAT driver from HMS
-    ip link set {interface} type can bitrate 1000000 dbitrate 2000000 fd on
-    ip link set {interface} up
     socketcan_test.py -d {interface} -f client -x stress-echo -l 100000 -c 123
 
 unit: template
 template-resource: com.canonical.certification::device
 template-filter: device.category == 'SOCKETCAN'
-id: socketcan/stress_remote_{interface}
+id: ce-oem-socketcan/stress_remote_{interface}
 _summary: Send stress test through CAN device {interface} (Raw, Remote)
 _description:
     Test a CAN device by sending packets using a raw socket to a remote device.
@@ -44,12 +37,22 @@ imports: from com.canonical.plainbox import manifest
 requires:
     manifest.socket_can_echo_server_running == 'True'
 command:
-    BASH_XTRACEFD=1
-    set -ex
-    ip link set {interface} down
-    # Following command is only supported configuration method when using the
-    # IXXAT driver from HMS
-    ip link set {interface} type can bitrate 1000000
-    ip link set dev {interface} mtu 16
-    ip link set {interface} up
     socketcan_test.py -d {interface} client -x stress-echo -l 100000 -c 123
+
+unit: template
+template-resource: com.canonical.certification::device
+template-filter: device.category == 'SOCKETCAN'
+id: ce-oem-socketcan/bus_off_recovery_{interface}
+_summary:  CAN device BUS-OFF recovery {interface}
+_description:
+    Test a CAN device will recovery automatically while it enter BUS-OFF state.
+category_id: com.canonical.certification::socketcan
+plugin: shell
+user: root
+estimated_duration: 10m
+flags: also-after-suspend
+imports: from com.canonical.plainbox import manifest
+requires:
+    manifest.socket_can_echo_server_running == 'True'
+command:
+    socketcan_busoff_test.py -d {interface} -t 60

--- a/checkbox-provider-ce-oem/units/socketcan/jobs.pxu
+++ b/checkbox-provider-ce-oem/units/socketcan/jobs.pxu
@@ -15,7 +15,7 @@ flags: also-after-suspend
 imports: from com.canonical.plainbox import manifest
 requires:
     manifest.socket_can_echo_server_running == 'True'
-    socket_can_fd == 'True'
+    manifest.has_socket_can_fd == 'True'
 command:
     socketcan_test.py -d {interface} -f client -x stress-echo -l 100000 -c 123
 

--- a/checkbox-provider-ce-oem/units/socketcan/manifest.pxu
+++ b/checkbox-provider-ce-oem/units/socketcan/manifest.pxu
@@ -1,5 +1,4 @@
 unit: manifest entry
 id: has_socket_can_fd
-_prompt: Is the CAN FD capable device:
 _name: CAN FD capable devices
 value-type: bool

--- a/checkbox-provider-ce-oem/units/socketcan/manifest.pxu
+++ b/checkbox-provider-ce-oem/units/socketcan/manifest.pxu
@@ -1,5 +1,5 @@
 unit: manifest entry
-id: socket_can_fd
+id: has_socket_can_fd
 _prompt: Is the CAN FD capable device:
 _name: CAN FD capable devices
 value-type: bool

--- a/checkbox-provider-ce-oem/units/socketcan/manifest.pxu
+++ b/checkbox-provider-ce-oem/units/socketcan/manifest.pxu
@@ -1,0 +1,5 @@
+unit: manifest entry
+id: socket_can_fd
+_prompt: Is the CAN FD capable device:
+_name: CAN FD capable devices
+value-type: bool

--- a/checkbox-provider-ce-oem/units/socketcan/test-plan.pxu
+++ b/checkbox-provider-ce-oem/units/socketcan/test-plan.pxu
@@ -1,0 +1,21 @@
+id: socketcan-stress-remote
+unit: test plan
+_name: SocketCAN send stress Tests (Automated, Remote)
+_description:
+    SocketCAN send stress Tests (Automated, Remote)
+bootstrap_include:
+    com.canonical.certification::device
+include:
+    socketcan/stress_fd_remote_.*
+    socketcan/stress_remote_.*
+
+id: after-suspend-socketcan-stress-remote
+unit: test plan
+_name: After suspend SocketCAN send stress Tests (Automated, Remote)
+_description:
+    After suspend SocketCAN send stress Tests (Automated, Remote)
+bootstrap_include:
+    com.canonical.certification::device
+include:
+    after-suspend-socketcan/stress_fd_remote_.*
+    after-suspend-socketcan/stress_remote_.*

--- a/checkbox-provider-ce-oem/units/socketcan/test-plan.pxu
+++ b/checkbox-provider-ce-oem/units/socketcan/test-plan.pxu
@@ -1,7 +1,7 @@
 id: ce-oem-socketcan-full
 unit: test plan
 _name: SocketCAN remote test
-_description: RS485 remote tests for devices
+_description: SocketCAN remote tests for devices
 include:
 nested_part:
     ce-oem-socketcan-manual

--- a/checkbox-provider-ce-oem/units/socketcan/test-plan.pxu
+++ b/checkbox-provider-ce-oem/units/socketcan/test-plan.pxu
@@ -1,4 +1,33 @@
-id: socketcan-stress-remote
+id: ce-oem-socketcan-full
+unit: test plan
+_name: SocketCAN remote test
+_description: RS485 remote tests for devices
+include:
+nested_part:
+    ce-oem-socketcan-manual
+    ce-oem-socketcan-stress-automated
+    after-suspend-ce-oem-socketcan-manual
+    after-suspend-ce-oem-socketcan-stress-automated
+
+id: ce-oem-socketcan-manual
+unit: test plan
+_name:  SocketCAN manual Tests (Manual, Remote)
+_description: SocketCAN manual Tests (Manual, Remote)
+bootstrap_include:
+    com.canonical.certification::device
+include:
+    ce-oem-socketcan/bus_off_recovery_.*
+
+id: after-suspend-ce-oem-socketcan-manual
+unit: test plan
+_name:  After suspend SocketCAN manual Tests (Manual, Remote)
+_description: After suspend SocketCAN manual Tests (Manual, Remote)
+bootstrap_include:
+    com.canonical.certification::device
+include:
+    after-suspend-ce-oem-socketcan/bus_off_recovery_.*
+
+id: ce-oem-socketcan-stress-automated
 unit: test plan
 _name: SocketCAN send stress Tests (Automated, Remote)
 _description:
@@ -6,10 +35,10 @@ _description:
 bootstrap_include:
     com.canonical.certification::device
 include:
-    socketcan/stress_fd_remote_.*
-    socketcan/stress_remote_.*
+    ce-oem-socketcan/stress_fd_remote_.*
+    ce-oem-socketcan/stress_remote_.*
 
-id: after-suspend-socketcan-stress-remote
+id: after-suspend-ce-oem-socketcan-stress-automated
 unit: test plan
 _name: After suspend SocketCAN send stress Tests (Automated, Remote)
 _description:
@@ -17,5 +46,5 @@ _description:
 bootstrap_include:
     com.canonical.certification::device
 include:
-    after-suspend-socketcan/stress_fd_remote_.*
-    after-suspend-socketcan/stress_remote_.*
+    after-suspend-ce-oem-socketcan/stress_fd_remote_.*
+    after-suspend-ce-oem-socketcan/stress_remote_.*


### PR DESCRIPTION
add new socketcan stress test (100000 loop echo test)

please refer the test results in Jira CQT-3562 issue
https://warthogs.atlassian.net/jira/software/projects/CQT/boards/418?selectedIssue=CQT-3562

Side-loading the checkbox and ran the socketcan-full test plan, please have the test results from C3:
- https://certification.canonical.com/hardware/202304-31451/submission/344073/
- https://certification.canonical.com/hardware/202304-31451/submission/344326/test-results/
following bus-off test failed as expected, I did not short the CAN_L and CAN_H in purpose.
- [after-suspend-ce-oem-socketcan/bus_off_recovery_can0](https://certification.canonical.com/hardware/202304-31451/submission/344073/test/204991/result/37757702/)
- [after-suspend-ce-oem-socketcan/bus_off_recovery_can1](https://certification.canonical.com/hardware/202304-31451/submission/344073/test/204992/result/37757703/)
