### PR TITLE
Add ubuntu-frame and glmark2 tests

### DIFF
--- a/checkbox-provider-ce-oem/bin/graphics_test.sh
+++ b/checkbox-provider-ce-oem/bin/graphics_test.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+test_ubuntu_frame_launching() {
+    if pgrep -if "ubuntu-frame" > /dev/null; then
+        echo "The ubuntu-frame is active"
+        echo "No need to bring it up again"
+        echo
+        echo "journal log of ubuntu frame:"
+        journalctl -b 0 | grep "ubuntu-frame"
+        touch "$PLAINBOX_SESSION_SHARE/ubuntu-frame-is-activating"
+        exit 0
+    else
+        echo "ubuntu-frame is not active"
+        echo "Activating now..."
+        echo
+        # Expecting exit code 124 from the 'timeout' command
+        # Capture any exit codes other than 0 and 124; return exit code 1 in such cases
+        timeout 20s ubuntu-frame || ( [[ $? -eq 124 ]] && \
+        echo -e "\nPASS: Timeout reached without any failures detected." )
+    fi
+}
+
+test_glmark2_es2_wayland() {
+    CMD="env XDG_RUNTIME_DIR=/run/user/0 graphics-test-tools.glmark2-es2-wayland"
+    OUTPUT=""
+    EXIT=0
+    if [ -f "$PLAINBOX_SESSION_SHARE/ubuntu-frame-is-activating" ]; then
+        echo "The ubuntu-frame is already active"
+        echo "Running glmark2-es2-wayland benchmark..."
+        echo
+        OUTPUT=$($CMD)
+        rm "$PLAINBOX_SESSION_SHARE/ubuntu-frame-is-activating"
+    else
+        echo "ubuntu-frame is not active"
+        echo "Activating now..."
+        echo
+        ubuntu-frame &
+        FRAME_PID=$!
+        sleep 10     # Sleep a while to make sure ubuntu-frame can be brought up before glamrk2-es2-wayland
+        echo "Running glmark2-es2-wayland benchmark..."
+        echo
+        OUTPUT=$($CMD)
+        kill "$FRAME_PID"
+    fi
+    echo "$OUTPUT"
+    if [ -z "$GL_VENDOR" ] || [ -z "$GL_RENDERER" ];then
+        echo "FAIL: 'GL_VENDOR' or 'GL_RENDERER' is empty. Please set them in config file!"
+        exit 1
+    fi
+    if ! echo "$OUTPUT" | grep "GL_VENDOR" | grep -q "$GL_VENDOR"; then
+        echo "FAIL: Wrong vendor!"
+        echo "The expected 'GL_VENDOR' should include '$GL_VENDOR'!"
+        EXIT=1
+    else
+        echo "PASS: GL_VENDOR is '$GL_VENDOR'"
+    fi
+    if ! echo "$OUTPUT" | grep "GL_RENDERER" | grep -q "$GL_RENDERER"; then
+        echo "FAIL: Wrong renderer!"
+        echo "The expected 'GL_RENDERER' should include '$GL_RENDERER'"
+        EXIT=1
+    else
+        echo "PASS: GL_RENDERER is '$GL_RENDERER'"
+    fi
+    exit $EXIT
+}
+
+help_function() {
+    echo "This script is used for graphics test cases"
+    echo "Usage: graphics_test.sh <test_case>"
+    echo
+    echo "Test cases currently implemented:"
+    echo -e "\t<frame>: test_ubuntu_frame_launching"
+    echo -e "\t<glmark2>: test_glmark2_es2_wayland"
+}
+
+main(){
+    case ${1} in
+        frame) test_ubuntu_frame_launching ;;
+        glmark2) test_glmark2_es2_wayland ;;
+        *) help_function ;;
+    esac
+}
+
+main "$@"

--- a/checkbox-provider-ce-oem/units/mir/category.pxu
+++ b/checkbox-provider-ce-oem/units/mir/category.pxu
@@ -1,0 +1,3 @@
+unit: category
+id: mir_test
+_name: Mir tests

--- a/checkbox-provider-ce-oem/units/mir/jobs.pxu
+++ b/checkbox-provider-ce-oem/units/mir/jobs.pxu
@@ -1,0 +1,29 @@
+id: mir/check-ubuntu-frame-launching-auto
+category_id: mir_test
+plugin: shell
+flags: also-after-suspend
+user: root
+imports:
+    from com.canonical.certification import snap
+    from com.canonical.plainbox import manifest
+requires:
+    snap.name == "ubuntu-frame"
+    manifest.has_ubuntu_frame == "True"
+_summary: Test if Ubuntu-Frame can be brought up
+command: graphics_test.sh frame
+
+id: mir/glmark2-es2-wayland-auto
+category_id: mir_test
+plugin: shell
+flags: also-after-suspend
+user: root
+depends: mir/check-ubuntu-frame-launching-auto
+imports: 
+    from com.canonical.certification import snap
+    from com.canonical.plainbox import manifest
+requires:
+    snap.name == "graphics-test-tools"
+    manifest.has_ubuntu_frame == "True"
+_summary: Run OpenGL ES 2.0 Wayland benchmark on the GPU
+environ: PLAINBOX_SESSION_SHARE GL_VENDOR GL_RENDERER
+command: graphics_test.sh glmark2

--- a/checkbox-provider-ce-oem/units/mir/manifest.pxu
+++ b/checkbox-provider-ce-oem/units/mir/manifest.pxu
@@ -1,0 +1,4 @@
+unit: manifest entry
+id: has_ubuntu_frame
+_name: Does platform support ubuntu-frame?
+value-type: bool

--- a/checkbox-provider-ce-oem/units/mir/test-plan.pxu
+++ b/checkbox-provider-ce-oem/units/mir/test-plan.pxu
@@ -1,0 +1,42 @@
+id: ce-oem-mir-full
+unit: test plan
+_name: Mir tests
+_description: Full graphics tests on Mir
+include:
+nested_part:
+    ce-oem-mir-manual
+    ce-oem-mir-automated
+    after-suspend-ce-oem-mir-manual
+    after-suspend-ce-oem-mir-automated
+
+id: ce-oem-mir-manual
+unit: test plan
+_name: Mir manual tests
+_description: Manual graphics tests on Mir
+include:
+
+id: ce-oem-mir-automated
+unit: test plan
+_name: Mir auto tests
+_description: Automated graphics tests on Mir
+bootstrap_include:
+    com.canonical.certification::snap
+include:
+    mir/check-ubuntu-frame-launching-auto
+    mir/glmark2-es2-wayland-auto
+
+id: after-suspend-ce-oem-mir-manual
+unit: test plan
+_name: After suspend Mir manual tests
+_description: Manual after-suspend graphics tests on Mir
+include:
+
+id: after-suspend-ce-oem-mir-automated
+unit: test plan
+_name: After suspend Mir auto tests
+_description: Automated after-suspend graphics tests on Mir
+bootstrap_include:
+    com.canonical.certification::snap
+include:
+    after-suspend-mir/check-ubuntu-frame-launching-auto
+    after-suspend-mir/glmark2-es2-wayland-auto


### PR DESCRIPTION
This PR introduced tests for `ubuntu-frame` and `glmark2-es2-wayland` benchmark.

For ubuntu-frame, we checked whether it is already launching in the background
* If yes, we dump the journal log relevant to ubuntu-frame
* If not, we try to launch it for 20 seconds to see if there's any launching error.

For glmark2-es2-wayland benchmark, we run it by `graphics-test-tools`
* Try to see whether we can run the benchmark successfully and get the glmark2 score.
* Check whether the `GL_VENDOR` and `GL_RENDERER` is correct.
  * To make sure the benchmark is running on the GPU, not by CPU software rendering (which the renderer starts with `llvm`)
  * `GL_VENDOR` and `GL_RENDERER` need to be specified in the config variables.

Also added an ubuntu-frame manifest.


Sideload test results:
* On Shiner MB touchscreen (uc20)
https://pastebin.canonical.com/p/6TX9dQF3Tb/
* On Mering device (uc22)
https://pastebin.canonical.com/p/SCRSBhcsjG/
* On Baoshan device (uc22) (both ubuntu-frame active and inactive before running the test)
https://pastebin.canonical.com/p/nkWwHtX4Ns/