### PR TITLE
Fix: refactor the thermal tests

### DIFF
--- a/checkbox-provider-ce-oem/bin/thermal_sensor_test.py
+++ b/checkbox-provider-ce-oem/bin/thermal_sensor_test.py
@@ -99,6 +99,7 @@ def thermal_monitor_test(args):
     initial_value = thermal_op.temperature
 
     result = False
+    proc = None
     try:
         proc = subprocess.Popen(shlex.split(cmd))
     except Exception:
@@ -115,7 +116,7 @@ def thermal_monitor_test(args):
                 args.name)
             break
         time.sleep(1)
-    if proc.poll() is None:
+    if proc and proc.poll() is None:
         # kill the subprocess if it is still alive
         proc.kill()
 

--- a/checkbox-provider-ce-oem/bin/thermal_sensor_test.py
+++ b/checkbox-provider-ce-oem/bin/thermal_sensor_test.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+import sys
+import time
+import logging
+import shlex
+import subprocess
+import argparse
+from pathlib import Path
+
+SYS_THERMAL_PATH = "/sys/class/thermal"
+
+
+def init_logger():
+    """
+    Set the logger to log DEBUG and INFO to stdout, and
+    WARNING, ERROR, CRITICAL to stderr.
+    """
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+    logger_format = "%(asctime)s %(levelname)-8s %(message)s"
+    date_format = "%Y-%m-%d %H:%M:%S"
+
+    # Log DEBUG and INFO to stdout, others to stderr
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setFormatter(logging.Formatter(logger_format, date_format))
+
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setFormatter(logging.Formatter(logger_format, date_format))
+
+    stdout_handler.setLevel(logging.DEBUG)
+    stderr_handler.setLevel(logging.WARNING)
+
+    # Add a filter to the stdout handler to limit log records to
+    # INFO level and below
+    stdout_handler.addFilter(lambda record: record.levelno <= logging.INFO)
+
+    root_logger.addHandler(stderr_handler)
+    root_logger.addHandler(stdout_handler)
+
+    return root_logger
+
+
+class ThermalMonitor():
+
+    def __init__(self, name):
+        self._name = name
+        self.root_node = Path(SYS_THERMAL_PATH).joinpath(self._name)
+        self.type_node = self.root_node.joinpath("type")
+        self.temp_node = self.root_node.joinpath("temp")
+        self.mode_node = self.root_node.joinpath("mode")
+        self.initial_temp = None
+
+    def _read_node(self, node):
+        if node.exists():
+            return node.read_text().strip("\n")
+        else:
+            raise FileNotFoundError("{} file not exists".format(str(node)))
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def type(self):
+        return self._read_node(self.type_node)
+
+    @property
+    def temperature(self):
+        temp = self._read_node(self.temp_node)
+        if not temp.isnumeric():
+            raise ValueError("temperate value is not a number!")
+        return temp
+
+    @property
+    def mode(self):
+        return self._read_node(self.mode_node)
+
+
+def check_temperature(current, initial):
+    logging.info("Initial value: %s, current value: %s", initial, current)
+    return (int(current) != 0 and current != initial)
+
+
+def thermal_monitor_test(args):
+    logging.info(
+        "# Monitor the temperature of %s thermal around %s seconds",
+        args.name, args.duration)
+
+    if args.extra_commands == "stress-ng":
+        cmd = "stress-ng --cpu 0 --io 4 --vm 2 --vm-bytes 128M --timeout 60s"
+    else:
+        cmd = args.extra_commands
+
+    result = False
+    try:
+        thermal_op = ThermalMonitor(args.name)
+        initial_value = thermal_op.temperature
+
+        with subprocess.Popen(shlex.split(cmd)) as proc:
+            for _ in range(args.duration):
+                cur_temp = thermal_op.temperature
+                result = check_temperature(cur_temp, initial_value)
+                if result:
+                    logging.info(
+                        "# The temperature of %s thermal has been altered",
+                        args.name)
+                    break
+                time.sleep(1)
+            proc.kill()
+    except subprocess.CalledProcessError:
+        # Bypass the subprocess error
+        pass
+
+    if result is False:
+        logging.error(
+            "# The temperature of the %s thermal remains consistently at %s",
+            args.name, initial_value)
+        raise SystemExit(1)
+
+
+def dump_thermal_zones(args):
+
+    for thermal in sorted(Path("/sys/class/thermal").glob("thermal_zone*")):
+        node = ThermalMonitor(thermal.name)
+        print("name: {}\nmode: {}\ntype: {}\n".format(
+                    node.name, node.mode, node.type))
+
+
+def register_arguments():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description='Thermal temperature Tests')
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Turn on debug level output for extra info during test run."
+    )
+
+    sub_parsers = parser.add_subparsers(
+        help="Thermal test type", dest="test_type", required=True)
+
+    monitor_parser = sub_parsers.add_parser("monitor")
+    monitor_parser.add_argument(
+        "-n", "--name",
+        required=True,
+        type=str
+    )
+    monitor_parser.add_argument(
+        "-d", "--duration",
+        type=int,
+        default=60
+    )
+    monitor_parser.add_argument(
+        "--extra-commands",
+        type=str,
+        default="stress-ng"
+    )
+    monitor_parser.set_defaults(test_type=thermal_monitor_test)
+
+    dump_parser = sub_parsers.add_parser("dump")
+    dump_parser.set_defaults(test_type=dump_thermal_zones)
+
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = register_arguments()
+    logger = init_logger()
+    if args.debug:
+        logger.setLevel(logging.DEBUG)
+
+    args.test_type(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/checkbox-provider-ce-oem/tests/test_thermal_sensor_test.py
+++ b/checkbox-provider-ce-oem/tests/test_thermal_sensor_test.py
@@ -1,0 +1,77 @@
+import unittest
+import argparse
+from unittest import mock
+import thermal_sensor_test
+
+
+class ThermalMonitorTest(unittest.TestCase):
+    """
+    Unit tests for thermal_monitor_test scripts
+    """
+    @mock.patch("pathlib.Path.read_text")
+    @mock.patch("pathlib.Path.exists")
+    def test_thermal_node_available(self, mock_file, mock_text):
+        """
+        Checking Thermal zone file exists
+        """
+        mock_results = ["apcitz", "enabled", "32000"]
+        expected_result = ["fake-thermal"]
+        expected_result.extend(mock_results)
+        mock_file.return_value = True
+        mock_text.side_effect = mock_results
+
+        thermal_node = thermal_sensor_test.ThermalMonitor("fake-thermal")
+        self.assertListEqual(
+            [
+                thermal_node.name, thermal_node.type,
+                thermal_node.mode, thermal_node.temperature
+            ],
+            expected_result
+        )
+
+    @mock.patch("pathlib.Path.exists")
+    def test_thermal_node_not_available(self, mock_file):
+        """
+        Checking Thermal zone file not exists
+        """
+        mock_file.return_value = False
+        with self.assertRaises(FileNotFoundError):
+            thermal_node = thermal_sensor_test.ThermalMonitor("fake-thermal")
+            thermal_node.type
+
+    @mock.patch("thermal_sensor_test.check_temperature")
+    @mock.patch("pathlib.Path.read_text")
+    @mock.patch("pathlib.Path.exists")
+    @mock.patch("subprocess.Popen")
+    def test_thermal_monitor_test_passed(
+            self, mock_popen, mock_file, mock_text, mock_check_temp):
+        """
+        Checking Thermal temperature has been altered
+        """
+        mock_args = mock.Mock(
+            return_value=argparse.Namespace(
+                name="fake-thermal", duration=30, extra_commands="stress-ng"))
+        mock_text.side_effect = ["30000", "30000", "31000"]
+        mock_check_temp.return_value = True
+
+        with self.assertLogs() as lc:
+            thermal_sensor_test.thermal_monitor_test(mock_args())
+            self.assertIn(
+                "# The temperature of fake-thermal thermal has been altered",
+                lc.output[-1]
+            )
+
+    @mock.patch("thermal_sensor_test.check_temperature")
+    @mock.patch("pathlib.Path.read_text")
+    @mock.patch("pathlib.Path.exists")
+    @mock.patch("subprocess.Popen")
+    def test_thermal_monitor_with_fixed_temperature(
+                    self, mock_popen, mock_file, mock_text, mock_check_temp):
+        mock_args = mock.Mock(
+            return_value=argparse.Namespace(
+                name="fake-thermal", duration=2, extra_commands="stress-ng"))
+        mock_text.return_value = "30000"
+        mock_check_temp.return_value = False
+
+        with self.assertRaises(SystemExit):
+            thermal_sensor_test.thermal_monitor_test(mock_args())

--- a/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
+++ b/checkbox-provider-ce-oem/units/test-plan-ce-oem.pxu
@@ -29,7 +29,7 @@ nested_part:
     ce-oem-installation-info-manual
     ce-oem-cpu-manual
     ce-oem-button-manual
-    ce-oem-sensor-manual
+    ce-oem-thermal-manual
     ce-oem-gps-manual
     ce-oem-mtd-manual
     ce-oem-buzzer-manual
@@ -59,7 +59,7 @@ nested_part:
     ce-oem-cpu-automated
     ce-oem-button-automated
     ce-oem-ptp-automated
-    ce-oem-sensor-automated
+    ce-oem-thermal-automated
     ce-oem-gps-automated
     ce-oem-mtd-automated
     ce-oem-buzzer-automated
@@ -88,7 +88,7 @@ include:
 nested_part:
     after-suspend-ce-oem-cpu-manual
     after-suspend-ce-oem-button-manual
-    after-suspend-ce-oem-sensor-manual
+    after-suspend-ce-oem-thermal-manual
     after-suspend-ce-oem-gps-manual
     after-suspend-ce-oem-mtd-manual
     after-suspend-ce-oem-buzzer-manual
@@ -116,7 +116,7 @@ nested_part:
     after-suspend-ce-oem-cpu-automated
     after-suspend-ce-oem-button-automated
     after-suspend-ce-oem-ptp-automated
-    after-suspend-ce-oem-sensor-automated
+    after-suspend-ce-oem-thermal-automated
     after-suspend-ce-oem-gps-automated
     after-suspend-ce-oem-mtd-automated
     after-suspend-ce-oem-buzzer-automated

--- a/checkbox-provider-ce-oem/units/thermal-sensor/category.pxu
+++ b/checkbox-provider-ce-oem/units/thermal-sensor/category.pxu
@@ -1,3 +1,3 @@
 unit: category
-id: sensor
-_name: Sensor
+id: thermal
+_name: Thermal

--- a/checkbox-provider-ce-oem/units/thermal-sensor/jobs.pxu
+++ b/checkbox-provider-ce-oem/units/thermal-sensor/jobs.pxu
@@ -1,16 +1,23 @@
-id: ce-oem-sensor/thermal
-_summary: Check Thermal sensor
+id: thermal_zones
+plugin: resource
+_summary: Gather list of thermal zone on the platform
+_description:
+ Gather list of all thermal zone on the platform
+estimated_duration: 1s
+command: thermal_sensor_test.py dump
+
+unit: template
+template-resource: thermal_zones
+template-filter: thermal_zones.mode == 'enabled'
+id: ce-oem-thermal/temperature_{name}_{type}
+_summary: Check Thermal temperature of {name} - {type}
+_description:
+    Test a thermal temperature for {name} - {type}.
+category_id: thermal
 plugin: shell
 user: root
+estimated_duration: 5m
+flags: also-after-suspend
+requires:
 command:
- echo "Starting stress-ng in 10s"
- sleep 10
- cur=$(cat /sys/class/thermal/thermal_zone0/temp)
- printf "Before stress: %0.2f°C\n" "$(bc -l <<< "$cur/1000")"
- stress-ng --cpu 8 --io 4 --vm 2 --vm-bytes 128M --fork 4 --timeout 20s
- new=$(cat /sys/class/thermal/thermal_zone0/temp)
- printf "After stress:  %0.2f°C\n" "$(bc -l <<< "$new/1000")"
- [[ $new -gt $cur ]]
-category_id: sensor
-estimated_duration: 30
-flags: preserve-locale also-after-suspend
+    thermal_sensor_test.py monitor -n {name}

--- a/checkbox-provider-ce-oem/units/thermal-sensor/jobs.pxu
+++ b/checkbox-provider-ce-oem/units/thermal-sensor/jobs.pxu
@@ -8,7 +8,6 @@ command: thermal_sensor_test.py dump
 
 unit: template
 template-resource: thermal_zones
-template-filter: thermal_zones.mode == 'enabled'
 id: ce-oem-thermal/temperature_{name}_{type}
 _summary: Check Thermal temperature of {name} - {type}
 _description:
@@ -18,6 +17,5 @@ plugin: shell
 user: root
 estimated_duration: 5m
 flags: also-after-suspend
-requires:
 command:
     thermal_sensor_test.py monitor -n {name}

--- a/checkbox-provider-ce-oem/units/thermal-sensor/test-plan.pxu
+++ b/checkbox-provider-ce-oem/units/thermal-sensor/test-plan.pxu
@@ -1,36 +1,40 @@
-id: ce-oem-sensor-full
+id: ce-oem-thermal-full
 unit: test plan
-_name: Thermal sensor tests
-_description: Full thermal sensor tests for devices
+_name: Thermal thermal tests
+_description: Full thermal thermal tests for devices
 include:
 nested_part:
-    ce-oem-sensor-manual
-    ce-oem-sensor-automated
-    after-suspend-ce-oem-sensor-manual
-    after-suspend-ce-oem-sensor-automated
+    ce-oem-thermal-manual
+    ce-oem-thermal-automated
+    after-suspend-ce-oem-thermal-manual
+    after-suspend-ce-oem-thermal-automated
 
-id: ce-oem-sensor-manual
+id: ce-oem-thermal-manual
 unit: test plan
-_name: Thermal sensor manual tests
-_description: Manual thermal sensor tests for devices
+_name: Thermal manual tests
+_description: Manual thermal tests for devices
 include:
 
-id: ce-oem-sensor-automated
+id: ce-oem-thermal-automated
 unit: test plan
-_name: Thermal sensor auto tests
-_description: Automated thermal sensor tests for devices
+_name: Thermal auto tests
+_description: Automated thermal tests for devices
+bootstrap_include:
+    thermal_zones
 include:
-    ce-oem-sensor/thermal
+    ce-oem-thermal/temperature_.*
 
-id: after-suspend-ce-oem-sensor-manual
+id: after-suspend-ce-oem-thermal-manual
 unit: test plan
-_name: After suspend thermal sensor manual tests
-_description: Manual after suspend thermal sensor tests for devices
+_name: After suspend thermal manual tests
+_description: Manual after suspend thermal tests for devices
 include:
 
-id: after-suspend-ce-oem-sensor-automated
+id: after-suspend-ce-oem-thermal-automated
 unit: test plan
-_name: After suspend thermal sensor auto tests
-_description: Automated after suspend thermal sensor tests for devices
+_name: After suspend thermal auto tests
+_description: Automated after suspend thermal tests for devices
+bootstrap_include:
+    thermal_zones
 include:
-    after-suspend-ce-oem-sensor/thermal
+    after-suspend-ce-oem-thermal/temperature_.*


### PR DESCRIPTION
refactor the thermal tests

#### side-load test results
https://certification.canonical.com/hardware/202309-32029/submission/349191/

#### list-bootstrapped result
```
u@u-APC2200:~$ checkbox-ce-oem.checkbox-cli list-bootstrapped com.canonical.qa.ceoem::ce-oem-automated | grep "thermal\|sensor"
$PROVIDERPATH is defined, so following provider sources are ignored ['/snap/checkbox-ce-oem/110/providers/checkbox-provider-ce-oem', '/home/u/.local/share/plainbox-providers-1', '/var/tmp/checkbox-providers-develop'] 
Using sideloaded provider: checkbox-provider-ce-oem, version 0.1 from /var/tmp/checkbox-providers/checkbox-provider-ce-oem
com.canonical.qa.ceoem::ce-oem-thermal/temperature_thermal_zone0_acpitz
com.canonical.qa.ceoem::ce-oem-thermal/temperature_thermal_zone1_x86_pkg_temp

u@u-APC2200:~$ checkbox-ce-oem.checkbox-cli list-bootstrapped com.canonical.qa.ceoem::after-suspend-ce-oem-automated | grep "thermal\|sensor"
$PROVIDERPATH is defined, so following provider sources are ignored ['/snap/checkbox-ce-oem/110/providers/checkbox-provider-ce-oem', '/home/u/.local/share/plainbox-providers-1', '/var/tmp/checkbox-providers-develop'] 
Using sideloaded provider: checkbox-provider-ce-oem, version 0.1 from /var/tmp/checkbox-providers/checkbox-provider-ce-oem
com.canonical.qa.ceoem::ce-oem-thermal/temperature_thermal_zone0_acpitz
com.canonical.qa.ceoem::after-suspend-ce-oem-thermal/temperature_thermal_zone0_acpitz
com.canonical.qa.ceoem::ce-oem-thermal/temperature_thermal_zone1_x86_pkg_temp
com.canonical.qa.ceoem::after-suspend-ce-oem-thermal/temperature_thermal_zone1_x86_pkg_temp
```