### PR TITLE
Refactor cpufreq tests with unit tests

### DIFF
--- a/checkbox-provider-ce-oem/bin/cpufreq_governors.py
+++ b/checkbox-provider-ce-oem/bin/cpufreq_governors.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import contextlib
 import logging
 import os
 import re
@@ -42,12 +43,121 @@ def init_logger():
     return root_logger
 
 
-class CPUScalingInfo:
-    """A class for gathering CPU scaling information."""
+def with_timeout(timeout=10, interval=0.5):
+    """
+    Decorator to set a timeout for a function's execution.
+
+    This decorator allows you to execute a function with a specified timeout
+    duration. If the function does not return `True` within the given timeout,
+    the wrapper function returns `False`. The wrapper function sleeps for a
+    specified interval between each invocation until the timeout expires.
+
+    Args:
+      - timeout (float, optional): Maximum time duration (in seconds) to wait
+        for the decorated function to return `True`. Defaults to 10 seconds.
+      - interval (float, optional): Time interval (in seconds) between
+        invocations within the timeout duration. Defaults to 0.5 seconds.
+
+    Returns:
+      - bool: Returns `True` if the decorated function returns `True` within
+        the specified timeout; otherwise, returns `False`.
+    """
+    def decorator(func):
+        def func_wrapper(*args, **kwargs):
+            start_time = time.time()
+            while time.time() - start_time < timeout:
+                if func(*args, **kwargs):
+                    return True
+                time.sleep(interval)
+            return False
+
+        return func_wrapper
+
+    return decorator
+
+
+def probe_governor_module(expected_governor):
+    """
+    Attempt to probe and load a specific CPU frequency governor module.
+
+    Args:
+      - expected_governor (str): The name of the CPU frequency governor module
+        to probe and load.
+
+    Raises:
+      - subprocess.CalledProcessError: If the 'modprobe' command encounters an
+        error during the module loading process.
+    """
+    logging.info(
+        "Seems CPU frequency governors %s are not enable yet.",
+        expected_governor,
+    )
+    module = "cpufreq_{}".format(expected_governor)
+    logging.info("Attempting to probe %s ...", module)
+    cmd = ["modprobe", module]
+    try:
+        subprocess.check_call(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            universal_newlines=True,
+            encoding="utf-8",
+        )
+        logging.info("Probe module Successfully!")
+    except subprocess.CalledProcessError as err:
+        logging.error(err)
+        logging.error("%s governor not supported", expected_governor)
+        sys.exit(1)
+
+
+def stress_cpus() -> List[subprocess.Popen]:
+    """
+    Stress the CPU cores by running multiple dd processes.
+
+    Returns:
+        subprocess.Popen: A list of Popen objects representing the
+                            dd processes spawned for each CPU core.
+    """
+    cpus_count = cpu_count()
+
+    cmd = ["dd", "if=/dev/zero", "of=/dev/null"]
+    processes = [subprocess.Popen(cmd) for _ in range(cpus_count)]
+    return processes
+
+
+def stop_stress_cpus(processes):
+    """
+    Stop the CPU stress by terminating the specified dd processes.
+
+    Args:
+        processes (List[subprocess.Popen]): A list of Popen objects
+                                            representing the dd processes.
+    """
+    for p in processes:
+        p.terminate()
+        p.wait()
+
+
+@contextlib.contextmanager
+def context_stress_cpus():
+    """
+    Context manager to stress CPU cores using multiple dd processes.
+    """
+    try:
+        logging.info("Stressing CPUs...")
+        processes = stress_cpus()
+        yield
+    finally:
+        logging.info("Stop stressing CPUs...")
+        stop_stress_cpus(processes)
+
+
+class CPUScalingHandler:
+    """A class for getting and setting CPU scaling information."""
 
     def __init__(self, policy=0):
         """
-        Initialize the CPUScalingInfo object.
+        Initialize the CPUScalingHandler object.
 
         Args:
             policy (int): The CPU policy number to be used (default is 0).
@@ -219,6 +329,17 @@ class CPUScalingInfo:
         frequency = self.get_policy_attribute("scaling_max_freq")
         return int(frequency) if frequency else 0
 
+    def get_current_frequency(self) -> int:
+        """
+        Get the current CPU frequency for the current policy.
+
+        Returns:
+            int: The current CPU frequency in kHz.
+        """
+        frequency = self.get_policy_attribute("scaling_cur_freq")
+        logging.debug("Current CPU frequency: %s", frequency)
+        return int(frequency) if frequency else 0
+
     def get_affected_cpus(self) -> List:
         """
         Get the list of affected CPUs for the current policy.
@@ -260,6 +381,60 @@ class CPUScalingInfo:
         """
         return self.set_policy_attribute("scaling_governor", governor)
 
+    @contextlib.contextmanager
+    def context_set_governor(self, governor):
+        """
+        Context manager to temporarily set a CPU frequency governor and
+        then restores the original governor.
+
+        Args:
+        - governor (str): The CPU frequency governor to set within the context.
+
+        Raises:
+        - SystemExit: If setting the governor fails during setup or teardown.
+        """
+        try:
+            if not self.set_policy_attribute("scaling_governor", governor):
+                sys.exit(1)
+            yield
+        finally:
+            logging.debug("-----------------TEARDOWN-----------------")
+            logging.debug(
+                "Restoring original governor to %s",
+                self.original_governor,
+            )
+            if not self.set_policy_attribute(
+                "scaling_governor", self.original_governor
+            ):
+                sys.exit(1)
+
+    @contextlib.contextmanager
+    def context_set_frequency(self, frequency):
+        """
+        Context manager to temporarily set a CPU frequency and
+        then restores the orignal frequency.
+
+        Args:
+        - frequency (str or int): The CPU frequency to set within the context.
+
+        Raises:
+        - SystemExit: If setting the frequency fails during setup or teardown.
+
+        """
+        try:
+            original_frequency = self.get_current_frequency()
+            if not self.set_frequency(frequency):
+                sys.exit(1)
+            yield
+        finally:
+            logging.debug("-----------------TEARDOWN-----------------")
+            logging.debug(
+                "Restoring original frequency to %s",
+                original_frequency,
+            )
+            if not self.set_frequency(original_frequency):
+                sys.exit(1)
+
     def set_frequency(self, frequency) -> bool:
         """
         Set the CPU frequency for the current policy.
@@ -286,33 +461,7 @@ class CPUScalingTest:
             policy (int): The CPU policy number to be used (default is 0).
         """
         self.policy = policy
-        self.info = CPUScalingInfo(policy=self.policy)
-
-    def stress_cpus(self) -> subprocess.Popen:
-        """
-        Stress the CPU cores by running multiple dd processes.
-
-        Returns:
-            subprocess.Popen: A list of Popen objects representing the
-                              dd processes spawned for each CPU core.
-        """
-        cpus_count = cpu_count()
-
-        cmd = ["dd", "if=/dev/zero", "of=/dev/null"]
-        processes = [subprocess.Popen(cmd) for _ in range(cpus_count)]
-        return processes
-
-    def stop_stress_cpus(self, processes):
-        """
-        Stop the CPU stress by terminating the specified dd processes.
-
-        Args:
-            processes (List[subprocess.Popen]): A list of Popen objects
-                                                representing the dd processes.
-        """
-        for p in processes:
-            p.terminate()
-            p.wait()
+        self.handler = CPUScalingHandler(policy=self.policy)
 
     def print_policy_info(self):
         """
@@ -320,26 +469,26 @@ class CPUScalingTest:
         """
         logging.info("## CPUfreq Policy%s Info ##", self.policy)
         logging.info("Affected CPUs:")
-        if not self.info.governors:
+        if not self.handler.governors:
             logging.info("    None")
         else:
-            for cpu in self.info.affected_cpus:
+            for cpu in self.handler.affected_cpus:
                 logging.info("    cpu%s", cpu)
 
         logging.info(
             "Supported CPU Frequencies: %s - %s MHz",
-            self.info.min_freq / 1000,
-            self.info.max_freq / 1000,
+            self.handler.min_freq / 1000,
+            self.handler.max_freq / 1000,
         )
 
         logging.info("Supported Governors:")
-        if not self.info.governors:
+        if not self.handler.governors:
             logging.info("    None")
         else:
-            for governor in self.info.governors:
+            for governor in self.handler.governors:
                 logging.info("    %s", governor)
 
-        logging.info("Current Governor: %s", self.info.original_governor)
+        logging.info("Current Governor: %s", self.handler.original_governor)
 
     def test_driver_detect(self) -> bool:
         """
@@ -353,18 +502,143 @@ class CPUScalingTest:
             bool: True if the drivers are printed successfully,
                   False otherwise.
         """
-        if not self.info.cpu_policies:
+        if not self.handler.cpu_policies:
             return False
         drivers = []
-        for policy in self.info.cpu_policies:
-            driver = self.info.get_scaling_driver(policy)
-            if driver not in drivers:
+        for policy in self.handler.cpu_policies:
+            driver = self.handler.get_scaling_driver(policy)
+            if driver and driver not in drivers:
                 drivers.append(driver)
         if not drivers:
             return False
         else:
             print("scaling_driver: {}".format(" ".join(drivers)))
             return True
+
+    @with_timeout()
+    def is_frequency_equal_to_target(self, target) -> bool:
+        """
+        Check if the current CPU frequency matches the target frequency.
+
+        Args:
+        - target (str or int): The target CPU frequency to compare against.
+
+        Returns:
+        - bool: Returns True if the current frequency matches the target
+                frequency; otherwise, returns False.
+        """
+        curr_freq = self.handler.get_current_frequency()
+        return curr_freq == target
+
+    @with_timeout()
+    def is_frequency_settled_down(self) -> bool:
+        """
+        Check if the current CPU frequency has settled down below the maximum.
+
+        Returns:
+        - bool: Returns True if the current frequency is below the maximum;
+                otherwise, returns False.
+        """
+        curr_freq = self.handler.get_current_frequency()
+        return curr_freq < self.handler.max_freq
+
+    def test_frequency_influence(self, governor, target_freq=None) -> bool:
+        """
+        Test the influence of CPU frequency based on the provided governor.
+
+        This function tests the influence of CPU frequency settings by
+        setting different governors and verifying if the CPU frequency
+        behaves as expected.
+
+        Args:
+        - governor (str): The CPU frequency governor to test.
+        - target_freq (int, optional): The target CPU frequency for the
+                                       'userspace' governor. Defaults to None.
+
+        Returns:
+        - bool: Returns True if all verification checks pass;
+                otherwise, returns False.
+
+        Raises:
+        - SystemExit: If an unsupported governor is provided.
+        """
+        frequencies_mapping = {
+            "performance": (self.handler.max_freq, "Max."),
+            "powersave": (self.handler.min_freq, "Min."),
+            "ondemand": (self.handler.max_freq, "Max."),
+            "conservative": (self.handler.max_freq, "Max."),
+            "schedutil": (self.handler.max_freq, "Max."),
+        }
+        success = True
+        with self.handler.context_set_governor(governor):
+            if governor in ["ondemand", "conservative", "schedutil"]:
+                with context_stress_cpus():
+                    if self.is_frequency_equal_to_target(
+                        target=frequencies_mapping[governor][0]
+                    ):
+                        logging.info(
+                            "Verified current CPU frequency is equal to "
+                            "%s frequency %s MHz",
+                            frequencies_mapping[governor][1],
+                            (frequencies_mapping[governor][0] / 1000),
+                        )
+                    else:
+                        success = False
+                        logging.error(
+                            "Could not verify that cpu frequency is equal to "
+                            "%s frequency %s MHz",
+                            frequencies_mapping[governor][1],
+                            (frequencies_mapping[governor][0] / 1000),
+                        )
+                if self.is_frequency_settled_down():
+                    logging.info(
+                        "Verified current CPU frequency has settled to a "
+                        "lower frequency"
+                    )
+                else:
+                    success = False
+                    logging.error(
+                        "Could not verify that cpu frequency has settled to a "
+                        "lower frequency"
+                    )
+            elif governor == "userspace":
+                with self.handler.context_set_frequency(target_freq):
+                    if self.is_frequency_equal_to_target(
+                        target=target_freq,
+                    ):
+                        logging.info(
+                            "Verified current CPU frequency is equal to "
+                            "frequency %s MHz",
+                            (target_freq / 1000),
+                        )
+                    else:
+                        success = False
+                        logging.error(
+                            "Could not verify that cpu frequency is equal to "
+                            "frequency %s MHz",
+                            (target_freq / 1000),
+                        )
+            elif governor in ["performance", "powersave"]:
+                if self.is_frequency_equal_to_target(
+                    target=frequencies_mapping[governor][0],
+                ):
+                    logging.info(
+                        "Verified current CPU frequency is close to "
+                        "%s frequency %s MHz",
+                        frequencies_mapping[governor][1],
+                        (frequencies_mapping[governor][0] / 1000),
+                    )
+                else:
+                    success = False
+                    logging.error(
+                        "Could not verify that cpu frequency has close to "
+                        "frequency %s MHz",
+                        frequencies_mapping[governor][1],
+                        (frequencies_mapping[governor][0] / 1000),
+                    )
+            else:
+                sys.exit("Governor '{}' not supported".format(governor))
+        return success
 
     def test_userspace(self) -> bool:
         """
@@ -374,54 +648,17 @@ class CPUScalingTest:
             bool: True if the test passes, False otherwise.
         """
         logging.info("-------------------------------------------------")
-        logging.info("Running Userspace Governor Test")
-        success = True
+        logging.info(
+            "Running Userspace Governor Test on CPU policy%s", self.policy
+        )
         governor = "userspace"
-        if governor not in self.info.governors:
-            if not self.probe_governor_module(governor):
-                return False
-
-        logging.info("Setting governor to %s", governor)
-        if not self.info.set_governor(governor):
-            success = False
-
-        # Set freq to minimum, verify
-        frequency = self.info.min_freq
-        logging.info(
-            "Setting CPU frequency to %u MHz", (int(frequency) / 1000)
+        return self.test_frequency_influence(
+            governor,
+            self.handler.max_freq,
+        ) and self.test_frequency_influence(
+            governor,
+            self.handler.min_freq,
         )
-        if not self.info.set_frequency(frequency):
-            success = False
-
-        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
-        if not curr_freq or (self.info.min_freq != curr_freq):
-            logging.error(
-                "Could not verify that cpu frequency is set to the minimum"
-                " value of %s",
-                self.info.min_freq,
-            )
-            success = False
-
-        # Set freq to maximum, verify
-        frequency = self.info.max_freq
-        logging.info(
-            "Setting CPU frequency to %u MHz", (int(frequency) / 1000)
-        )
-        if not self.info.set_frequency(frequency):
-            success = False
-
-        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
-        if not curr_freq or (self.info.max_freq != curr_freq):
-            logging.error(
-                "Could not verify that cpu frequency is set to the minimum"
-                " value of %s",
-                self.info.max_freq,
-            )
-            success = False
-
-        if success:
-            logging.info("Userspace Governor Test: PASS")
-        return success
 
     def test_performance(self) -> bool:
         """
@@ -431,36 +668,11 @@ class CPUScalingTest:
             bool: True if the test passes, False otherwise.
         """
         logging.info("-------------------------------------------------")
-        logging.info("Running Performance Governor Test")
-        success = True
-        governor = "performance"
-        if governor not in self.info.governors:
-            if not self.probe_governor_module(governor):
-                return False
-
-        logging.info("Setting governor to %s", governor)
-        if not self.info.set_governor(governor):
-            success = False
-
-        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
-        logging.debug(
-            "Verifying current CPU frequency %s is close to max frequency",
-            curr_freq,
+        logging.info(
+            "Running Performance Governor Test on CPU policy%s", self.policy
         )
-        if not curr_freq or (
-            float(curr_freq) < 0.99 * float(self.info.max_freq)
-        ):
-            logging.error(
-                "Current cpu frequency of %s is not close enough to the "
-                "maximum value of %s",
-                curr_freq,
-                self.info.max_freq,
-            )
-            success = False
-
-        if success:
-            logging.info("Performance Governor Test: PASS")
-        return success
+        governor = "performance"
+        return self.test_frequency_influence(governor)
 
     def test_powersave(self) -> bool:
         """
@@ -470,36 +682,11 @@ class CPUScalingTest:
             bool: True if the test passes, False otherwise.
         """
         logging.info("-------------------------------------------------")
-        logging.info("Running Powersave Governor Test")
-        success = True
-        governor = "powersave"
-        if governor not in self.info.governors:
-            if not self.probe_governor_module(governor):
-                return False
-
-        logging.info("Setting governor to %s", governor)
-        if not self.info.set_governor(governor):
-            success = False
-
-        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
-        logging.debug(
-            "Verifying current CPU frequency %s is close to min frequency",
-            curr_freq,
+        logging.info(
+            "Running Powersave Governor Test on CPU policy%s", self.policy
         )
-        if not curr_freq or (
-            float(curr_freq) * 0.99 > float(self.info.min_freq)
-        ):
-            logging.error(
-                "Current cpu frequency of %s is not close enough to the "
-                "minimum value of %s",
-                curr_freq,
-                self.info.min_freq,
-            )
-            success = False
-
-        if success:
-            logging.info("Powersave Governor Test: PASS")
-        return success
+        governor = "powersave"
+        return self.test_frequency_influence(governor)
 
     def test_ondemand(self) -> bool:
         """
@@ -512,62 +699,8 @@ class CPUScalingTest:
         logging.info(
             "Running Ondemand Governor Test on CPU policy%s", self.policy
         )
-        success = True
         governor = "ondemand"
-        if governor not in self.info.governors:
-            if not self.probe_governor_module(governor):
-                return False
-
-        logging.info("Setting governor to %s", governor)
-        if not self.info.set_governor(governor):
-            success = False
-
-        logging.info("Stressing CPUs...")
-        stress_process = self.stress_cpus()
-        time.sleep(5)
-
-        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
-        logging.debug("Current CPU frequency: %s MHz", (curr_freq / 1000))
-        if (
-            not self.info.max_freq
-            or not curr_freq
-            or (self.info.max_freq != curr_freq)
-        ):
-            logging.error(
-                "Could not verify that cpu frequency has increased to the "
-                "maximum value"
-            )
-            success = False
-        else:
-            logging.info(
-                "Verified current CPU frequency is equal to the max frequency"
-            )
-
-        logging.info("Stop stressing CPUs...")
-        self.stop_stress_cpus(stress_process)
-        time.sleep(8)
-
-        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
-        logging.debug("Current CPU frequency: %s MHz", (curr_freq / 1000))
-        if (
-            not self.info.min_freq
-            or not curr_freq
-            or (self.info.max_freq <= curr_freq)
-        ):
-            logging.error(
-                "Could not verify that cpu frequency has settled to a "
-                "lower frequency"
-            )
-            success = False
-        else:
-            logging.info(
-                "Verified current CPU frequency has settled to a "
-                "lower frequency"
-            )
-
-        if success:
-            logging.info("Ondemand Governor Test: PASS")
-        return success
+        return self.test_frequency_influence(governor)
 
     def test_conservative(self) -> bool:
         """
@@ -580,62 +713,8 @@ class CPUScalingTest:
         logging.info(
             "Running Conservative Governor Test on CPU policy%s", self.policy
         )
-        success = True
         governor = "conservative"
-        if governor not in self.info.governors:
-            if not self.probe_governor_module(governor):
-                return False
-
-        logging.info("Setting governor to %s", governor)
-        if not self.info.set_governor(governor):
-            success = False
-
-        logging.info("Stressing CPUs...")
-        stress_process = self.stress_cpus()
-        time.sleep(5)
-
-        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
-        logging.debug("Current CPU frequency: %s MHz", (curr_freq / 1000))
-        if (
-            not self.info.max_freq
-            or not curr_freq
-            or (self.info.max_freq != curr_freq)
-        ):
-            logging.error(
-                "Could not verify that cpu frequency has increased to the "
-                "maximum value"
-            )
-            success = False
-        else:
-            logging.info(
-                "Verified current CPU frequency is equal to the max frequency"
-            )
-
-        logging.info("Stop stressing CPUs...")
-        self.stop_stress_cpus(stress_process)
-        time.sleep(8)
-
-        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
-        logging.debug("Current CPU frequency: %s MHz", (curr_freq / 1000))
-        if (
-            not self.info.min_freq
-            or not curr_freq
-            or (self.info.max_freq <= curr_freq)
-        ):
-            logging.error(
-                "Could not verify that cpu frequency has settled to a "
-                "lower frequency"
-            )
-            success = False
-        else:
-            logging.info(
-                "Verified current CPU frequency has settled to a "
-                "lower frequency"
-            )
-
-        if success:
-            logging.info("Conservative Governor Test: PASS")
-        return success
+        return self.test_frequency_influence(governor)
 
     def test_schedutil(self) -> bool:
         """
@@ -648,101 +727,11 @@ class CPUScalingTest:
         logging.info(
             "Running Schedutil Governor Test on CPU policy%s", self.policy
         )
-        success = True
         governor = "schedutil"
-        if governor not in self.info.governors:
-            if not self.probe_governor_module(governor):
-                return False
-
-        logging.info("Setting governor to %s", governor)
-        if not self.info.set_governor(governor):
-            success = False
-
-        logging.info("Stressing CPUs...")
-        stress_process = self.stress_cpus()
-        time.sleep(5)
-
-        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
-        logging.debug("Current CPU frequency: %s MHz", (curr_freq / 1000))
-        if (
-            not self.info.max_freq
-            or not curr_freq
-            or (self.info.max_freq != curr_freq)
-        ):
-            logging.error(
-                "Could not verify that cpu frequency has increased to the "
-                "maximum value"
-            )
-            success = False
-        else:
-            logging.info(
-                "Verified current CPU frequency is equal to the max frequency"
-            )
-
-        logging.info("Stop stressing CPUs...")
-        self.stop_stress_cpus(stress_process)
-        time.sleep(8)
-
-        curr_freq = int(self.info.get_policy_attribute("scaling_cur_freq"))
-        logging.debug("Current CPU frequency: %s MHz", (curr_freq / 1000))
-        if (
-            not self.info.min_freq
-            or not curr_freq
-            or (self.info.max_freq <= curr_freq)
-        ):
-            logging.error(
-                "Could not verify that cpu frequency has settled to a "
-                "lower frequency"
-            )
-            success = False
-        else:
-            logging.info(
-                "Verified current CPU frequency has settled to a "
-                "lower frequency"
-            )
-
-        if success:
-            logging.info("Schedutil Governor Test: PASS")
-        return success
-
-    def restore_governor(self):
-        """
-        Restore the CPU governor to the original value.
-
-        This method sets the CPU governor to the original governor value
-        stored during initialization.
-        """
-        logging.info("-------------------------------------------------")
-        logging.info(
-            "Restoring original governor to %s",
-            self.info.original_governor
-        )
-        self.info.set_governor(self.info.original_governor)
-
-    def probe_governor_module(self, expected_governor):
-        logging.info("Seems CPU frequency governors %s are not"
-                     " enable yet.", expected_governor)
-        module = ("cpufreq_{}".format(expected_governor))
-        logging.info("Attempting to probe %s ...", module)
-        cmd = ["modprobe", module]
-        try:
-            subprocess.run(
-                cmd,
-                check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-                encoding="utf-8"
-            )
-            logging.info("Probe module Successfully!")
-            return True
-        except subprocess.CalledProcessError as err:
-            logging.error(err)
-            logging.error("%s governor not supported", expected_governor)
-            return False
+        return self.test_frequency_influence(governor)
 
 
-def main():
+if __name__ == "__main__":
     """
     Execute the CPU scaling test based on the provided command-line arguments.
 
@@ -754,9 +743,6 @@ def main():
         --driver-detect: Print the CPU scaling driver.
         --policy: Run the test on a specific CPU policy (default is policy 0).
         --governor: Run a specific governor test.
-
-    Returns:
-        int: The exit code of the test execution, 0 if successful, 1 otherwise.
     """
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -779,7 +765,7 @@ def main():
         "--policy",
         dest="policy",
         help="Run test on specific policy",
-        default="0",
+        default=0,
     )
     parser.add_argument(
         "--governor",
@@ -792,27 +778,21 @@ def main():
     if args.debug:
         logger.setLevel(logging.DEBUG)
 
-    info = CPUScalingInfo()
+    handler = CPUScalingHandler()
     if args.policy_resource:
-        info.print_policies_list()
-        return 0
+        handler.print_policies_list()
+        sys.exit(0)
 
     test = CPUScalingTest(policy=args.policy)
     if args.driver_detect:
-        return 0 if test.test_driver_detect() else 1
+        sys.exit(0) if test.test_driver_detect() else sys.exit(1)
 
-    exit_code = 0
     try:
         test.print_policy_info()
+        if args.governor not in handler.governors:
+            probe_governor_module(args.governor)
         if not getattr(test, "test_{}".format(args.governor))():
-            exit_code = 1
+            sys.exit(1)
     except AttributeError:
         logging.exception("Given governor is not supported")
-        return 1
-
-    test.restore_governor()
-    return exit_code
-
-
-if __name__ == "__main__":
-    sys.exit(main())
+        sys.exit(1)

--- a/checkbox-provider-ce-oem/tests/test_cpufreq_governors.py
+++ b/checkbox-provider-ce-oem/tests/test_cpufreq_governors.py
@@ -2,155 +2,894 @@
 
 import unittest
 import subprocess
-import io
+from unittest.mock import patch, mock_open, Mock, MagicMock
 import logging
-from unittest import mock
-"""
-We probably could remove append path while mirge back to ppc.
-Since checkbox has __init__.py for unit tests.
-ref:
-https://github.com/canonical/checkbox/blob/main/checkbox-support/checkbox_support/tests/__init__.py
-"""
 import sys
-import os
-# Add the path to the 'bin' directory for the import to work
-sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'bin'))
-from cpufreq_governors import CPUScalingInfo, CPUScalingTest
+import io
+
+from cpufreq_governors import (
+    CPUScalingHandler,
+    CPUScalingTest,
+    init_logger,
+    probe_governor_module,
+    stress_cpus,
+    stop_stress_cpus,
+    context_stress_cpus,
+)
+
+
+class TestInitLogger(unittest.TestCase):
+    @patch("logging.StreamHandler")
+    @patch("logging.Formatter")
+    @patch("logging.getLogger")
+    def test_init_logger(
+        self, mock_get_logger, mock_formatter, mock_stream_handler
+    ):
+        mock_logger = Mock()
+        mock_get_logger.return_value = mock_logger
+
+        returned_logger = init_logger()
+
+        self.assertEqual(returned_logger, mock_logger)
+
+        # Directly accessing the methods on the mock object
+        mock_stream_handler_instance = mock_stream_handler.return_value
+        mock_formatter_instance = mock_formatter.return_value
+
+        # Check if setFormatter is called with the mock formatter
+        mock_stream_handler_instance.setFormatter.assert_called_with(
+            mock_formatter_instance
+        )
+        mock_logger.addHandler.assert_called()
+
+
+class TestProbeGovernorModule(unittest.TestCase):
+    @patch("subprocess.check_call")
+    @patch("sys.exit")
+    @patch("logging.info")
+    def test_probe_governor_module_success(
+        self, mock_logging_info, mock_sys_exit, mock_subprocess_check_call
+    ):
+        mock_subprocess_check_call.return_value = None
+
+        probe_governor_module("ondemand")
+
+        mock_logging_info.assert_called_with("Probe module Successfully!")
+        # Ensure sys.exit was not called
+        mock_sys_exit.assert_not_called()
+
+    @patch("subprocess.check_call")
+    @patch("sys.exit")
+    @patch("logging.error")
+    def test_probe_governor_module_error(
+        self, mock_logging_error, mock_sys_exit, mock_subprocess_check_call
+    ):
+        mock_subprocess_check_call.side_effect = subprocess.CalledProcessError(
+            1, "modprobe"
+        )
+
+        probe_governor_module("invalid_governor")
+
+        mock_logging_error.assert_called_with(
+            "%s governor not supported", "invalid_governor"
+        )
+        # Ensure sys.exit was called with 1
+        mock_sys_exit.assert_called_with(1)
+
+
+class TestCPUSStress(unittest.TestCase):
+    @patch("cpufreq_governors.subprocess.Popen")
+    @patch("cpufreq_governors.cpu_count")
+    def test_stress_cpus(self, mock_cpu_count, mock_popen):
+        mock_cpu_count.return_value = 4  # Simulating 4 CPU cores
+        mock_popen_instance = MagicMock()
+        mock_popen.return_value = (
+            mock_popen_instance  # Mocking the Popen object
+        )
+
+        stress_cpus()
+
+        # Assert that the Popen was called 4 times
+        self.assertEqual(mock_popen.call_count, 4)
+        # Check if the Popen was called with the correct command
+        mock_popen.assert_called_with(["dd", "if=/dev/zero", "of=/dev/null"])
+
+    @patch("cpufreq_governors.subprocess.Popen")
+    def test_stop_stress_cpus(self, mock_popen):
+        # Mocking a list of mock Popen objects
+        mock_processes = [
+            MagicMock() for _ in range(4)
+        ]  # Simulating 4 CPU cores
+
+        stop_stress_cpus(mock_processes)
+
+        for mock_process in mock_processes:
+            mock_process.terminate.assert_called_once()
+            mock_process.wait.assert_called_once()
+
+    @patch("cpufreq_governors.stress_cpus")
+    def test_context_stress_cpus(self, mock_stress_cpus):
+        # Mocking the return value of stress_cpus
+        mock_stress_cpus.return_value = [
+            MagicMock() for _ in range(4)
+        ]  # Simulating 4 CPU cores
+
+        # Using the context manager for context_stress_cpus
+        with context_stress_cpus():
+            pass
+
+        mock_stress_cpus.assert_called_once()
+
+
+class TestCPUScalingHandler(unittest.TestCase):
+    def setUp(self):
+        suppress_text = io.StringIO()
+        sys.stdout = suppress_text
+        logging.disable()
+        self.cpu_scaling_info = CPUScalingHandler()
+        self.cpu_scaling_info.sys_cpu_dir = "/sys/devices/system/cpu"
+
+    @patch("os.listdir")
+    def test_get_cpu_policies_success(self, mock_listdir):
+        """Check if a sorted list contains cpu policy number can be returned
+        while policies exist.
+        """
+        mock_listdir.return_value = ["policy0", "policy1", "policy2"]
+
+        policies = self.cpu_scaling_info.get_cpu_policies()
+
+        self.assertEqual(policies, [0, 1, 2])
+
+    @patch("os.listdir")
+    def test_get_cpu_policies_failure(self, mock_listdir):
+        """Check if an empty list be returned while OSError"""
+        # Mock the listdir function to raise an OSError
+        mock_listdir.side_effect = OSError("OSError")
+
+        result = self.cpu_scaling_info.get_cpu_policies()
+
+        self.assertEqual(result, [])
+
+    @patch("os.listdir")
+    def test_get_cpu_policies_failure_empty(self, mock_listdir):
+        """Check if an empty list be returned while no policy exists"""
+        # Mock the listdir function to return an empty list
+        mock_listdir.return_value = []
+
+        result = self.cpu_scaling_info.get_cpu_policies()
+
+        self.assertEqual(result, [])
+
+    @patch("builtins.open", mock_open(read_data="Driver"))
+    def test_get_scaling_driver_success(self):
+        """Check if the name of driver be returned"""
+        # Mock the open function to return a scaling driver
+        result = self.cpu_scaling_info.get_scaling_driver()
+
+        self.assertEqual(result, "Driver")
+
+    @patch("builtins.open")
+    def test_get_scaling_driver_oserror(self, mock_open):
+        """Check if an empty string be returned while OSError"""
+        # Mock the open function to raise an OSError
+        mock_open.side_effect = OSError("OSError")
+
+        result = self.cpu_scaling_info.get_scaling_driver()
+
+        self.assertEqual(result, "")
+
+    @patch(
+        "cpufreq_governors.CPUScalingHandler.get_scaling_driver",
+        return_value="some_driver_name",
+    )
+    @patch("builtins.print")  # Mock the built-in print function
+    def test_print_policies_list_success(
+        self, mock_print, mock_get_scaling_driver
+    ):
+        scaling_info = CPUScalingHandler(policy=0)
+        scaling_info.cpu_policies = [0, 1]
+
+        result = scaling_info.print_policies_list()
+
+        mock_get_scaling_driver.assert_any_call(0)
+        mock_get_scaling_driver.assert_any_call(1)
+        # Ensure that the method returns True when successful
+        self.assertTrue(result)
+
+    @patch(
+        "cpufreq_governors.CPUScalingHandler.get_scaling_driver",
+        return_value="",
+    )
+    @patch("builtins.print")  # Mock the built-in print function
+    def test_print_policies_list_failure(
+        self, mock_print, mock_get_scaling_driver
+    ):
+        scaling_info = CPUScalingHandler(policy=0)
+
+        with patch.object(scaling_info, "cpu_policies", False):
+            result = scaling_info.print_policies_list()
+            self.assertFalse(result)
+
+    @patch("builtins.open", mock_open(read_data="Attribute_Value"))
+    def test_get_attribute_success(self):
+        """Check if get_attribute gets the contain of specific node"""
+        # Mock the open function to return a attribute value
+        result = self.cpu_scaling_info.get_attribute("Attribute")
+
+        self.assertEqual(result, "Attribute_Value")
+
+    @patch("builtins.open", side_effect=OSError)
+    def test_get_attribute_oserror(self, mock_open):
+        """Check if get_attribute gets an empty string while OSError occurs"""
+        # Mock the open function to raise an OSError
+        result = self.cpu_scaling_info.get_attribute("Attribute")
+
+        self.assertEqual(result, "")
+
+    @patch("builtins.open", new_callable=mock_open, create=True)
+    def test_set_attribute_success(self, mock_open):
+        """Check if returns True while setting a value to a specific node"""
+        mock_file = mock_open.return_value
+        result = self.cpu_scaling_info.set_attribute(
+            "attribute_name", "new_value"
+        )
+
+        mock_file.write.assert_called_once_with("new_value")
+        self.assertTrue(result)
+
+    @patch("builtins.open", side_effect=PermissionError)
+    def test_set_attribute_permissionerror(self, mock_open):
+        """Check if returns False while PermissionError occurs"""
+        # Mock the open function to raise an PermissionError
+        result = self.cpu_scaling_info.set_attribute(
+            "attribute_name", "new_value"
+        )
+
+        self.assertFalse(result)
+
+    @patch("builtins.open", side_effect=OSError)
+    def test_set_attribute_oserror(self, mock_open):
+        """Check if returns False while OSError occurs"""
+        # Mock the open function to raise an OSError
+        result = self.cpu_scaling_info.set_attribute(
+            "attribute_name", "new_value"
+        )
+
+        self.assertFalse(result)
+
+    @patch(
+        "cpufreq_governors.CPUScalingHandler.set_attribute",
+        return_value=True,
+    )
+    def test_set_policy_attribute_success(self, mock_set_attribute):
+        result = self.cpu_scaling_info.set_policy_attribute(
+            "some_attr", "some_value"
+        )
+
+        self.assertTrue(result)
+
+    @patch(
+        "cpufreq_governors.CPUScalingHandler.get_policy_attribute",
+        return_value="1000000",
+    )
+    def test_get_min_frequency_success(self, mock_get_policy_attribute):
+        result = self.cpu_scaling_info.get_min_frequency()
+
+        mock_get_policy_attribute.assert_called_once_with("scaling_min_freq")
+
+        self.assertEqual(result, 1000000)
+
+    @patch(
+        "cpufreq_governors.CPUScalingHandler.get_policy_attribute",
+        return_value=None,
+    )
+    def test_get_min_frequency_with_no_frequency(
+        self, mock_get_policy_attribute
+    ):
+        result = self.cpu_scaling_info.get_min_frequency()
+
+        mock_get_policy_attribute.assert_called_once_with("scaling_min_freq")
+
+        # Expected frequency is 0 when no value is returned
+        self.assertEqual(result, 0)
+
+    @patch(
+        "cpufreq_governors.CPUScalingHandler.get_policy_attribute",
+        return_value="1000000",
+    )
+    def test_get_max_frequency_success(self, mock_get_policy_attribute):
+        result = self.cpu_scaling_info.get_max_frequency()
+
+        mock_get_policy_attribute.assert_called_once_with("scaling_max_freq")
+
+        self.assertEqual(result, 1000000)
+
+    @patch(
+        "cpufreq_governors.CPUScalingHandler.get_policy_attribute",
+        return_value=None,
+    )
+    def test_get_max_frequency_with_no_frequency(
+        self, mock_get_policy_attribute
+    ):
+        result = self.cpu_scaling_info.get_max_frequency()
+
+        mock_get_policy_attribute.assert_called_once_with("scaling_max_freq")
+
+        # Expected frequency is 0 when no value is returned
+        self.assertEqual(result, 0)
+
+    @patch(
+        "cpufreq_governors.CPUScalingHandler.get_policy_attribute",
+        return_value="1000000",
+    )
+    def test_get_current_frequency_success(self, mock_get_policy_attribute):
+        result = self.cpu_scaling_info.get_current_frequency()
+
+        mock_get_policy_attribute.assert_called_once_with("scaling_cur_freq")
+
+        self.assertEqual(result, 1000000)
+
+    @patch(
+        "cpufreq_governors.CPUScalingHandler.get_policy_attribute",
+        return_value=None,
+    )
+    def test_get_current_frequency_with_no_frequency(
+        self, mock_get_policy_attribute
+    ):
+        result = self.cpu_scaling_info.get_current_frequency()
+
+        mock_get_policy_attribute.assert_called_once_with("scaling_cur_freq")
+
+        self.assertEqual(result, 0)
+
+    @patch(
+        "cpufreq_governors.CPUScalingHandler.get_policy_attribute",
+        return_value="0 1 2 3",
+    )
+    def test_get_affected_cpus_with_spaces_success(
+        self, mock_get_policy_attribute
+    ):
+        result = self.cpu_scaling_info.get_affected_cpus()
+
+        mock_get_policy_attribute.assert_called_once_with("affected_cpus")
+
+        self.assertEqual(result, ["0", "1", "2", "3"])
+
+    @patch(
+        "cpufreq_governors.CPUScalingHandler.get_policy_attribute",
+        return_value="",
+    )
+    def test_get_affected_cpus_with_no_value(self, mock_get_policy_attribute):
+        result = self.cpu_scaling_info.get_affected_cpus()
+
+        mock_get_policy_attribute.assert_called_once_with("affected_cpus")
+
+        self.assertEqual(result, [])
+
+    @patch(
+        "cpufreq_governors.CPUScalingHandler.set_policy_attribute",
+        return_value=True,
+    )
+    def test_set_governor_success(self, mock_set_policy_attribute):
+        result = self.cpu_scaling_info.set_governor("ondemand")
+
+        mock_set_policy_attribute.assert_called_once_with(
+            "scaling_governor", "ondemand"
+        )
+
+        self.assertTrue(result)
+
+    @patch(
+        "cpufreq_governors.CPUScalingHandler.set_policy_attribute",
+        return_value=False,
+    )
+    def test_set_governor_failure(self, mock_set_policy_attribute):
+        result = self.cpu_scaling_info.set_governor("performance")
+
+        mock_set_policy_attribute.assert_called_once_with(
+            "scaling_governor", "performance"
+        )
+
+        self.assertFalse(result)
+
+    @patch(
+        "cpufreq_governors.CPUScalingHandler.set_policy_attribute",
+        return_value=True,
+    )
+    def test_context_set_governor_success(self, mock_set_policy_attribute):
+        # Using the context manager
+        with self.cpu_scaling_info.context_set_governor("ondemand"):
+            mock_set_policy_attribute.assert_called_once_with(
+                "scaling_governor", "ondemand"
+            )
+
+    @patch(
+        "cpufreq_governors.CPUScalingHandler.set_policy_attribute",
+        return_value=False,
+    )
+    def test_context_set_governor_failure(self, mock_set_policy_attribute):
+        # Using the context manager with an expected failure
+        try:
+            with self.cpu_scaling_info.context_set_governor("performance"):
+                mock_set_policy_attribute.assert_called_once_with(
+                    "scaling_governor", "performance"
+                )
+        except SystemExit:
+            # Exception caught as expected
+            pass
+        else:
+            self.fail("Expected SystemExit")
+
+    @patch(
+        "cpufreq_governors.CPUScalingHandler.set_frequency", return_value=True
+    )
+    def test_context_set_frequency_success(self, mock_set_frequency):
+        # Using the context manager
+        with self.cpu_scaling_info.context_set_frequency("1200000"):
+            mock_set_frequency.assert_called_once_with("1200000")
+
+    @patch(
+        "cpufreq_governors.CPUScalingHandler.set_frequency", return_value=False
+    )
+    def test_context_set_frequency_failure(self, mock_set_frequency):
+        # Using the context manager with an expected failure
+        try:
+            with self.cpu_scaling_info.context_set_frequency("1200000"):
+                mock_set_frequency.assert_called_once_with("1200000")
+        except SystemExit:
+            # Exception caught as expected
+            pass
+        else:
+            self.fail("Expected SystemExit")
+
+    @patch(
+        "cpufreq_governors.CPUScalingHandler.set_policy_attribute",
+        return_value=True,
+    )
+    def test_set_frequency_success(self, mock_set_policy_attribute):
+        result = self.cpu_scaling_info.set_frequency("1200000")
+
+        mock_set_policy_attribute.assert_called_once_with(
+            "scaling_setspeed", "1200000"
+        )
+
+        self.assertTrue(result)
+
+    @patch(
+        "cpufreq_governors.CPUScalingHandler.set_policy_attribute",
+        return_value=False,
+    )
+    def test_set_frequency_failure(self, mock_set_policy_attribute):
+        result = self.cpu_scaling_info.set_frequency("1200000")
+
+        mock_set_policy_attribute.assert_called_once_with(
+            "scaling_setspeed", "1200000"
+        )
+
+        self.assertFalse(result)
 
 
 class TestCPUScalingTest(unittest.TestCase):
-    @mock.patch('cpufreq_governors.CPUScalingInfo',
-                return_value=None)
-    def setUp(self, mock_cpuscalinginfo):
-        suppress_text = io.StringIO()
-        sys.stdout = suppress_text
+    @patch("cpufreq_governors.CPUScalingHandler")
+    def test_print_policy_info(self, mock_cpuscalinghandler):
+        mock_handler_instance = Mock()
+        mock_handler_instance.affected_cpus = [0, 1, 2]
+        mock_handler_instance.min_freq = 1000000  # 1000 kHz
+        mock_handler_instance.max_freq = 3000000  # 3000 kHz
+        mock_handler_instance.governors = ["governor1", "governor2"]
+        mock_handler_instance.original_governor = "original_governor_value"
+
+        mock_cpuscalinghandler.return_value = mock_handler_instance
+
+        cpu_scaling_test = CPUScalingTest(policy=0)
+        expected_logs = [
+            "INFO:root:## CPUfreq Policy0 Info ##",
+            "INFO:root:Affected CPUs:",
+            "INFO:root:    cpu0",
+            "INFO:root:    cpu1",
+            "INFO:root:    cpu2",
+            "INFO:root:Supported CPU Frequencies: 1000.0 - 3000.0 MHz",
+            "INFO:root:Supported Governors:",
+            "INFO:root:    governor1",
+            "INFO:root:    governor2",
+            "INFO:root:Current Governor: original_governor_value",
+        ]
+        with self.assertLogs(level="INFO") as lc:
+            logging.disable(logging.NOTSET)
+            cpu_scaling_test.print_policy_info()
+            for i in range(len(expected_logs)):
+                self.assertEqual(expected_logs[i], lc.output[i])
         logging.disable(logging.CRITICAL)
-        # Create an instance of CPUScalingTest
-        self.cpu_scaling_test = CPUScalingTest()
 
-    @mock.patch('subprocess.run')
-    def test_probe_governor_module_success(self, mock_subprocess_run):
-        # Simulate a scenario governor module probe successfully.
-        governor = "test_governor"
-        status = self.cpu_scaling_test.probe_governor_module(
-            governor
-            )
-        mock_subprocess_run.returncode = 0
-        self.assertLogs("Probe module Successfully!")
-        self.assertTrue(status)
+    @patch("cpufreq_governors.CPUScalingHandler")
+    def test_print_policy_info_no_governor(self, mock_cpuscalinghandler):
+        mock_handler_instance = Mock()
+        mock_handler_instance.affected_cpus = [0, 1, 2]
+        mock_handler_instance.min_freq = 1000000  # 1000 kHz
+        mock_handler_instance.max_freq = 3000000  # 3000 kHz
+        mock_handler_instance.governors = []
+        mock_handler_instance.original_governor = "original_governor_value"
 
-    @mock.patch('subprocess.run')
-    def test_probe_governor_module_fail(self, mock_subprocess_run):
-        # Simulate a scenario where the governors module probed fail.
-        # Create a mock subprocess.CompletedProcess object with a
-        # return code of SystemError
-        governor = "test_governor"
-        cmd = ["modprobe", governor]
-        mock_subprocess_run.side_effect = subprocess.CalledProcessError(
-            returncode=1,
-            cmd=cmd,
-        )
-        status = self.cpu_scaling_test.probe_governor_module(governor)
-        self.assertLogs("governor not supported")
-        self.assertFalse(status)
+        mock_cpuscalinghandler.return_value = mock_handler_instance
 
-    def tearDown(self):
-        # release stdout
-        sys.stdout = sys.__stdout__
-        logging.disable(logging.NOTSET)
+        cpu_scaling_test = CPUScalingTest(policy=0)
+        expected_logs = [
+            "INFO:root:## CPUfreq Policy0 Info ##",
+            "INFO:root:Affected CPUs:",
+            "INFO:root:    None",
+            "INFO:root:Supported CPU Frequencies: 1000.0 - 3000.0 MHz",
+            "INFO:root:Supported Governors:",
+            "INFO:root:    None",
+            "INFO:root:Current Governor: original_governor_value",
+        ]
+        with self.assertLogs(level="INFO") as lc:
+            logging.disable(logging.NOTSET)
+            cpu_scaling_test.print_policy_info()
+            for i in range(len(expected_logs)):
+                self.assertEqual(expected_logs[i], lc.output[i])
+        logging.disable()
 
+    @patch("cpufreq_governors.CPUScalingHandler")
+    def test_driver_detect_empty_policies(self, mock_cpuscalinghandler):
+        mock_handler_instance = Mock()
+        mock_handler_instance.cpu_policies = []
+        mock_handler_instance.get_scaling_driver.return_value = "driver_a"
+        mock_cpuscalinghandler.return_value = mock_handler_instance
 
-class TestCPUScalingInfo(unittest.TestCase):
-    @mock.patch('cpufreq_governors.CPUScalingInfo.__init__',
-                return_value=None)
-    def setUp(self,
-              mock_init):
-        suppress_text = io.StringIO()
-        sys.stdout = suppress_text
-        logging.disable(logging.CRITICAL)
-        CPUScalingInfo.__init__ = mock_init
-        # Create an instance of CPUScalingInfo
-        self.cpu_scaling_info = CPUScalingInfo()
-        self.cpu_scaling_info.sys_cpu_dir = "/sys/devices/system/cpu"
+        instance = CPUScalingTest(policy=0)
+        result = instance.test_driver_detect()
 
-    @mock.patch('os.listdir')
-    def test_get_cpu_policies_success(self, mock_listdir):
-        # Mock the listdir function to return a list of CPU policies
-        mock_listdir.return_value = ["policy0", "policy1", "policy2"]
-        # Call the get_cpu_policies function
-        policies = self.cpu_scaling_info.get_cpu_policies()
+        self.assertFalse(result)
 
-        # Assert that the function returns the expected list of policies
-        self.assertEqual(policies, [0, 1, 2])
+    @patch("cpufreq_governors.CPUScalingHandler")
+    def test_driver_detect_single_driver(self, mock_cpuscalinghandler):
+        mock_handler_instance = Mock()
+        mock_handler_instance.cpu_policies = [1, 2]
+        mock_handler_instance.get_scaling_driver.return_value = "driver_a"
+        mock_cpuscalinghandler.return_value = mock_handler_instance
 
-    @mock.patch('os.listdir')
-    def test_get_cpu_policies_failure(self, mock_listdir):
-        # Mock the listdir function to raise an OSError
-        mock_listdir.side_effect = OSError("OSError")
-        result = self.cpu_scaling_info.get_cpu_policies()
-        self.assertEqual(result, [])
+        instance = CPUScalingTest(policy=0)
+        result = instance.test_driver_detect()
 
-    @mock.patch('os.listdir')
-    def test_get_cpu_policies_failure_empty(self, mock_listdir):
-        # Mock the listdir function to return an empty list
-        mock_listdir.return_value = []
-        result = self.cpu_scaling_info.get_cpu_policies()
-        self.assertEqual(result, [])
-
-    @mock.patch('builtins.open', mock.mock_open(read_data='Driver'))
-    def test_get_scaling_driver_success(self):
-        # Mock the open function to return a scaling driver
-        result = self.cpu_scaling_info.get_scaling_driver()
-        self.assertEqual(result, "Driver")
-
-    @mock.patch('builtins.open', side_effect=OSError)
-    def test_get_scaling_driver_oserror(self, mock_open):
-        # Mock the open function to raise an OSError
-        result = self.cpu_scaling_info.get_scaling_driver()
-        self.assertEqual(result, "")
-
-    @mock.patch('builtins.open', mock.mock_open(read_data='Attribute_Value'))
-    def test_get_attribute_success(self):
-        # Mock the open function to return a attribute value
-        result = self.cpu_scaling_info.get_attribute("Attribute")
-        self.assertEqual(result, "Attribute_Value")
-
-    @mock.patch('builtins.open', side_effect=OSError)
-    def test_get_attribute_oserror(self, mock_open):
-        # Mock the open function to raise an OSError
-        result = self.cpu_scaling_info.get_attribute("Attribute")
-        self.assertEqual(result, "")
-
-    @mock.patch('builtins.open', new_callable=mock.mock_open, create=True)
-    def test_set_attribute_success(self, mock_open):
-        mock_file = mock_open.return_value
-        result = self.cpu_scaling_info.set_attribute(
-            'attribute_name',
-            'new_value')
-        mock_file.write.assert_called_once_with('new_value')
         self.assertTrue(result)
 
-    @mock.patch('builtins.open', side_effect=PermissionError)
-    def test_set_attribute_permissionerror(self, mock_open):
-        # Mock the open function to raise an OSError
-        result = self.cpu_scaling_info.set_attribute(
-            'attribute_name',
-            'new_value')
+    @patch("cpufreq_governors.CPUScalingHandler")
+    def test_driver_detect_multiple_drivers(self, mock_cpuscalinghandler):
+        mock_handler_instance = Mock()
+        mock_handler_instance.cpu_policies = [1, 2]
+        mock_handler_instance.get_scaling_driver.side_effect = [
+            "driver_a",
+            "driver_b",
+        ]
+        mock_cpuscalinghandler.return_value = mock_handler_instance
+
+        instance = CPUScalingTest(policy=0)
+        result = instance.test_driver_detect()
+
+        self.assertTrue(result)
+
+    @patch("cpufreq_governors.CPUScalingHandler")
+    def test_driver_detect_no_drivers_found(self, mock_cpuscalinghandler):
+        mock_handler_instance = Mock()
+        mock_handler_instance.cpu_policies = [1, 2]
+        mock_handler_instance.get_scaling_driver.return_value = []
+        mock_cpuscalinghandler.return_value = mock_handler_instance
+
+        instance = CPUScalingTest(policy=0)
+
+        result = instance.test_driver_detect()
         self.assertFalse(result)
 
-    @mock.patch('builtins.open', side_effect=OSError)
-    def test_set_attribute_oserror(self, mock_open):
-        # Mock the open function to raise an OSError
-        result = self.cpu_scaling_info.set_attribute(
-            'attribute_name',
-            'new_value')
+    @patch("cpufreq_governors.time")
+    def test_is_frequency_equal_to_target_success(self, mock_time):
+        # Mocking the current time and the get_current_frequency method
+        # This simulates time-based checks
+        mock_time.time.side_effect = [0, 0.5, 1]
+        instance = CPUScalingTest(policy=0)
+
+        mock_handler = Mock()
+        mock_handler.get_current_frequency.return_value = 1000
+        instance.handler = mock_handler
+
+        # Set the target frequency to 1000 for this test
+        target_freq = 1000
+
+        result = instance.is_frequency_equal_to_target(target_freq)
+        self.assertTrue(result)
+
+    @patch("cpufreq_governors.time")
+    def test_is_frequency_equal_to_target_timeout(self, mock_time):
+        # Mocking the current time and the get_current_frequency method
+        # This simulates time-based checks
+        mock_time.time.side_effect = [0, 0.5, 11]
+        instance = CPUScalingTest(policy=0)
+
+        mock_handler = Mock()
+        mock_handler.get_current_frequency.return_value = 900
+        instance.handler = mock_handler
+
+        target_freq = 1000
+
+        result = instance.is_frequency_equal_to_target(target_freq)
         self.assertFalse(result)
 
-    def tearDown(self):
-        # release stdout
-        sys.stdout = sys.__stdout__
-        logging.disable(logging.NOTSET)
+    @patch("cpufreq_governors.time")
+    def test_is_frequency_settled_down_success(self, mock_time):
+        # Mocking the current time and the get_current_frequency method
+        # This simulates time-based checks
+        mock_time.time.side_effect = [0, 0.5, 1]
+        instance = CPUScalingTest(policy=0)
+
+        mock_handler = Mock()
+        mock_handler.get_current_frequency.return_value = 900
+        mock_handler.max_freq = 1000
+        instance.handler = mock_handler
+
+        result = instance.is_frequency_settled_down()
+        self.assertTrue(result)
+
+    @patch("cpufreq_governors.time")
+    def test_is_frequency_settled_down_failure(self, mock_time):
+        # Mocking the current time and the get_current_frequency method
+        # This simulates time-based checks
+        mock_time.time.side_effect = [0, 0.5, 11]
+        instance = CPUScalingTest(policy=0)
+
+        # Mocking the get_current_frequency method to return a value
+        # greater than or equal to max_freq
+        mock_handler = Mock()
+        mock_handler.get_current_frequency.return_value = 1100
+        mock_handler.max_freq = 1000
+        instance.handler = mock_handler
+
+        result = instance.is_frequency_settled_down()
+        self.assertFalse(result)
+
+    @patch("cpufreq_governors.CPUScalingTest.is_frequency_settled_down")
+    @patch("cpufreq_governors.CPUScalingTest.is_frequency_equal_to_target")
+    @patch("cpufreq_governors.context_stress_cpus")
+    @patch("cpufreq_governors.CPUScalingHandler.context_set_governor")
+    def test_frequency_influence_ondemand_success(
+        self,
+        mock_context_set_governor,
+        mock_context_stress_cpus,
+        mock_is_frequency_equal_to_target,
+        mock_is_frequency_settled_down,
+    ):
+        mock_is_frequency_equal_to_target.return_value = True
+        mock_is_frequency_settled_down.return_value = True
+
+        instance = CPUScalingTest(policy=0)
+        result = instance.test_frequency_influence(governor="ondemand")
+
+        self.assertTrue(result)
+
+    @patch("cpufreq_governors.CPUScalingTest.is_frequency_settled_down")
+    @patch("cpufreq_governors.CPUScalingTest.is_frequency_equal_to_target")
+    @patch("cpufreq_governors.context_stress_cpus")
+    @patch("cpufreq_governors.CPUScalingHandler.context_set_governor")
+    def test_frequency_influence_ondemand_frequency_not_equal(
+        self,
+        mock_context_set_governor,
+        mock_context_stress_cpus,
+        mock_is_frequency_equal_to_target,
+        mock_is_frequency_settled_down,
+    ):
+        mock_is_frequency_equal_to_target.return_value = False
+        mock_is_frequency_settled_down.return_value = True
+
+        instance = CPUScalingTest(policy=0)
+        result = instance.test_frequency_influence(governor="ondemand")
+
+        self.assertFalse(result)
+
+    @patch("cpufreq_governors.CPUScalingTest.is_frequency_settled_down")
+    @patch("cpufreq_governors.CPUScalingTest.is_frequency_equal_to_target")
+    @patch("cpufreq_governors.context_stress_cpus")
+    @patch("cpufreq_governors.CPUScalingHandler.context_set_governor")
+    def test_frequency_influence_ondemand_settled_down_failure(
+        self,
+        mock_context_set_governor,
+        mock_context_stress_cpus,
+        mock_is_frequency_equal_to_target,
+        mock_is_frequency_settled_down,
+    ):
+        mock_is_frequency_equal_to_target.return_value = True
+        mock_is_frequency_settled_down.return_value = False
+
+        instance = CPUScalingTest(policy=0)
+        result = instance.test_frequency_influence(governor="ondemand")
+
+        self.assertFalse(result)
+
+    @patch("cpufreq_governors.CPUScalingTest.is_frequency_equal_to_target")
+    @patch("cpufreq_governors.CPUScalingHandler.context_set_frequency")
+    @patch("cpufreq_governors.CPUScalingHandler.context_set_governor")
+    def test_frequency_influence_userspace_success(
+        self,
+        mock_context_set_governor,
+        mock_context_set_frequency,
+        mock_is_frequency_equal_to_target,
+    ):
+        mock_is_frequency_equal_to_target.return_value = True
+
+        instance = CPUScalingTest(policy=0)
+        result = instance.test_frequency_influence(
+            governor="userspace", target_freq=1000
+        )
+
+        self.assertTrue(result)
+
+    @patch("cpufreq_governors.CPUScalingTest.is_frequency_equal_to_target")
+    @patch("cpufreq_governors.CPUScalingHandler.context_set_frequency")
+    @patch("cpufreq_governors.CPUScalingHandler.context_set_governor")
+    def test_frequency_influence_userspace_failure(
+        self,
+        mock_context_set_governor,
+        mock_context_set_frequency,
+        mock_is_frequency_equal_to_target,
+    ):
+        mock_is_frequency_equal_to_target.return_value = False
+
+        instance = CPUScalingTest(policy=0)
+        result = instance.test_frequency_influence(
+            governor="userspace", target_freq=1000
+        )
+
+        self.assertFalse(result)
+
+    @patch("cpufreq_governors.CPUScalingTest.is_frequency_equal_to_target")
+    @patch("cpufreq_governors.CPUScalingHandler.context_set_governor")
+    def test_frequency_influence_performance_success(
+        self,
+        mock_context_set_governor,
+        mock_is_frequency_equal_to_target,
+    ):
+        mock_is_frequency_equal_to_target.return_value = True
+
+        instance = CPUScalingTest(policy=0)
+        result = instance.test_frequency_influence(
+            governor="performance", target_freq=1000
+        )
+
+        self.assertTrue(result)
+
+    @patch("cpufreq_governors.CPUScalingTest.is_frequency_equal_to_target")
+    @patch("cpufreq_governors.CPUScalingHandler.context_set_governor")
+    def test_frequency_influence_performance_failure(
+        self,
+        mock_context_set_governor,
+        mock_is_frequency_equal_to_target,
+    ):
+        mock_is_frequency_equal_to_target.return_value = False
+
+        instance = CPUScalingTest(policy=0)
+        result = instance.test_frequency_influence(
+            governor="performance", target_freq=1000
+        )
+
+        self.assertFalse(result)
+
+    @patch("sys.exit")
+    @patch("cpufreq_governors.CPUScalingHandler.context_set_governor")
+    def test_frequency_influence_invalid_governor(
+        self,
+        mock_context_set_governor,
+        mock_exit,
+    ):
+        instance = CPUScalingTest(policy=0)
+        instance.test_frequency_influence(governor="no_governor")
+
+        mock_exit.assert_called_with("Governor 'no_governor' not supported")
+
+    @patch("cpufreq_governors.CPUScalingTest.test_frequency_influence")
+    def test_test_userspace_success(self, mock_test_frequency_influence):
+        mock_test_frequency_influence.side_effect = [True, True]
+
+        instance = CPUScalingTest(policy=0)
+        result = instance.test_userspace()
+
+        self.assertTrue(result)
+
+    @patch("cpufreq_governors.CPUScalingTest.test_frequency_influence")
+    def test_test_userspace_failure(self, mock_test_frequency_influence):
+        mock_test_frequency_influence.side_effect = [False, True]
+
+        instance = CPUScalingTest(policy=0)
+        result = instance.test_userspace()
+
+        self.assertFalse(result)
+
+    @patch("cpufreq_governors.CPUScalingTest.test_frequency_influence")
+    def test_test_performance_success(self, mock_test_frequency_influence):
+        mock_test_frequency_influence.return_value = True
+
+        instance = CPUScalingTest(policy=0)
+        result = instance.test_performance()
+
+        self.assertTrue(result)
+
+    @patch("cpufreq_governors.CPUScalingTest.test_frequency_influence")
+    def test_test_performance_failure(self, mock_test_frequency_influence):
+        mock_test_frequency_influence.return_value = False
+
+        instance = CPUScalingTest(policy=0)
+        result = instance.test_performance()
+
+        self.assertFalse(result)
+
+    @patch("cpufreq_governors.CPUScalingTest.test_frequency_influence")
+    def test_test_powersave_success(self, mock_test_frequency_influence):
+        mock_test_frequency_influence.return_value = True
+
+        instance = CPUScalingTest(policy=0)
+        result = instance.test_powersave()
+
+        self.assertTrue(result)
+
+    @patch("cpufreq_governors.CPUScalingTest.test_frequency_influence")
+    def test_test_powersave_failure(self, mock_test_frequency_influence):
+        mock_test_frequency_influence.return_value = False
+
+        instance = CPUScalingTest(policy=0)
+        result = instance.test_powersave()
+
+        self.assertFalse(result)
+
+    @patch("cpufreq_governors.CPUScalingTest.test_frequency_influence")
+    def test_test_ondemand_success(self, mock_test_frequency_influence):
+        mock_test_frequency_influence.return_value = True
+
+        instance = CPUScalingTest(policy=0)
+        result = instance.test_ondemand()
+
+        self.assertTrue(result)
+
+    @patch("cpufreq_governors.CPUScalingTest.test_frequency_influence")
+    def test_test_ondemand_failure(self, mock_test_frequency_influence):
+        mock_test_frequency_influence.return_value = False
+
+        instance = CPUScalingTest(policy=0)
+        result = instance.test_ondemand()
+
+        self.assertFalse(result)
+
+    @patch("cpufreq_governors.CPUScalingTest.test_frequency_influence")
+    def test_test_conservative_success(self, mock_test_frequency_influence):
+        mock_test_frequency_influence.return_value = True
+
+        instance = CPUScalingTest(policy=0)
+        result = instance.test_conservative()
+
+        self.assertTrue(result)
+
+    @patch("cpufreq_governors.CPUScalingTest.test_frequency_influence")
+    def test_test_conservative_failure(self, mock_test_frequency_influence):
+        mock_test_frequency_influence.return_value = False
+
+        instance = CPUScalingTest(policy=0)
+        result = instance.test_conservative()
+
+        self.assertFalse(result)
+
+    @patch("cpufreq_governors.CPUScalingTest.test_frequency_influence")
+    def test_test_schedutil_success(self, mock_test_frequency_influence):
+        mock_test_frequency_influence.return_value = True
+
+        instance = CPUScalingTest(policy=0)
+        result = instance.test_schedutil()
+
+        self.assertTrue(result)
+
+    @patch("cpufreq_governors.CPUScalingTest.test_frequency_influence")
+    def test_test_schedutil_failure(self, mock_test_frequency_influence):
+        mock_test_frequency_influence.return_value = False
+
+        instance = CPUScalingTest(policy=0)
+        result = instance.test_schedutil()
+
+        self.assertFalse(result)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/checkbox-provider-ce-oem/tests/test_cpufreq_governors.py
+++ b/checkbox-provider-ce-oem/tests/test_cpufreq_governors.py
@@ -122,12 +122,21 @@ class TestCPUSStress(unittest.TestCase):
 
 
 class TestCPUScalingHandler(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
+        cls.original_stdout = sys.stdout
         suppress_text = io.StringIO()
         sys.stdout = suppress_text
         logging.disable(logging.CRITICAL)
+
+    def setUp(self):
         self.cpu_scaling_info = CPUScalingHandler()
         self.cpu_scaling_info.sys_cpu_dir = "/sys/devices/system/cpu"
+
+    @classmethod
+    def tearDownClass(cls):
+        sys.stdout = cls.original_stdout
+        logging.disable(logging.NOTSET)
 
     @patch("os.listdir")
     def test_get_cpu_policies_success(self, mock_listdir):
@@ -468,13 +477,15 @@ class TestCPUScalingHandler(unittest.TestCase):
 
         self.assertFalse(result)
 
-    def tearDown(self):
-        logging.disable(logging.NOTSET)
-
 
 class TestCPUScalingTest(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         logging.disable(logging.CRITICAL)
+
+    @classmethod
+    def tearDownClass(cls):
+        logging.disable(logging.NOTSET)
 
     @patch("cpufreq_governors.CPUScalingHandler")
     def test_print_policy_info(self, mock_cpuscalinghandler):
@@ -895,9 +906,6 @@ class TestCPUScalingTest(unittest.TestCase):
         result = instance.test_schedutil()
 
         self.assertFalse(result)
-
-    def tearDown(self):
-        logging.disable(logging.NOTSET)
 
 
 if __name__ == "__main__":

--- a/checkbox-provider-ce-oem/tests/test_cpufreq_governors.py
+++ b/checkbox-provider-ce-oem/tests/test_cpufreq_governors.py
@@ -125,7 +125,7 @@ class TestCPUScalingHandler(unittest.TestCase):
     def setUp(self):
         suppress_text = io.StringIO()
         sys.stdout = suppress_text
-        logging.disable()
+        logging.disable(logging.CRITICAL)
         self.cpu_scaling_info = CPUScalingHandler()
         self.cpu_scaling_info.sys_cpu_dir = "/sys/devices/system/cpu"
 
@@ -468,8 +468,15 @@ class TestCPUScalingHandler(unittest.TestCase):
 
         self.assertFalse(result)
 
+    def tearDown(self):
+        logging.disable(logging.NOTSET)
+
 
 class TestCPUScalingTest(unittest.TestCase):
+
+    def setUp(self):
+        logging.disable(logging.CRITICAL)
+
     @patch("cpufreq_governors.CPUScalingHandler")
     def test_print_policy_info(self, mock_cpuscalinghandler):
         mock_handler_instance = Mock()
@@ -499,7 +506,7 @@ class TestCPUScalingTest(unittest.TestCase):
             cpu_scaling_test.print_policy_info()
             for i in range(len(expected_logs)):
                 self.assertEqual(expected_logs[i], lc.output[i])
-        logging.disable(logging.CRITICAL)
+            logging.disable(logging.CRITICAL)
 
     @patch("cpufreq_governors.CPUScalingHandler")
     def test_print_policy_info_no_governor(self, mock_cpuscalinghandler):
@@ -527,7 +534,7 @@ class TestCPUScalingTest(unittest.TestCase):
             cpu_scaling_test.print_policy_info()
             for i in range(len(expected_logs)):
                 self.assertEqual(expected_logs[i], lc.output[i])
-        logging.disable()
+            logging.disable(logging.CRITICAL)
 
     @patch("cpufreq_governors.CPUScalingHandler")
     def test_driver_detect_empty_policies(self, mock_cpuscalinghandler):
@@ -889,6 +896,9 @@ class TestCPUScalingTest(unittest.TestCase):
         result = instance.test_schedutil()
 
         self.assertFalse(result)
+
+    def tearDown(self):
+        logging.disable(logging.NOTSET)
 
 
 if __name__ == "__main__":

--- a/checkbox-provider-ce-oem/tests/test_cpufreq_governors.py
+++ b/checkbox-provider-ce-oem/tests/test_cpufreq_governors.py
@@ -40,7 +40,7 @@ class TestInitLogger(unittest.TestCase):
         mock_stream_handler_instance.setFormatter.assert_called_with(
             mock_formatter_instance
         )
-        mock_logger.addHandler.assert_called()
+        self.assertEqual(mock_logger.addHandler.call_count, 2)
 
 
 class TestProbeGovernorModule(unittest.TestCase):
@@ -104,8 +104,8 @@ class TestCPUSStress(unittest.TestCase):
         stop_stress_cpus(mock_processes)
 
         for mock_process in mock_processes:
-            mock_process.terminate.assert_called_once()
-            mock_process.wait.assert_called_once()
+            self.assertEqual(mock_process.terminate.call_count, 1)
+            self.assertEqual(mock_process.wait.call_count, 1)
 
     @patch("cpufreq_governors.stress_cpus")
     def test_context_stress_cpus(self, mock_stress_cpus):
@@ -118,7 +118,7 @@ class TestCPUSStress(unittest.TestCase):
         with context_stress_cpus():
             pass
 
-        mock_stress_cpus.assert_called_once()
+        self.assertEqual(mock_stress_cpus.call_count, 1)
 
 
 class TestCPUScalingHandler(unittest.TestCase):
@@ -473,7 +473,6 @@ class TestCPUScalingHandler(unittest.TestCase):
 
 
 class TestCPUScalingTest(unittest.TestCase):
-
     def setUp(self):
         logging.disable(logging.CRITICAL)
 


### PR DESCRIPTION
* Refactor the CPU frequency tests refer to the comments in https://github.com/canonical/checkbox/pull/765 . The test logic is the same, only the code structure has been refactored.
* Add the unit tests for it.

Sideload results:
* on Baoshan device
https://pastebin.canonical.com/p/QmS5KKB2tF/
* on Baytown device
https://pastebin.canonical.com/p/bB7jBwGTMp/